### PR TITLE
Fixed display of navbar

### DIFF
--- a/src/javascripts/components/staffButton.js
+++ b/src/javascripts/components/staffButton.js
@@ -1,11 +1,9 @@
 const staffButton = () => `<div id="staff-container" class="nav-cards-left">
-                        <div class="card staff-button-card button-card" style="width: 18rem;">
-                        <div class="card-body middle">
-                          <h5 class="card-title">Staff Card</h5>
-                          <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-                          <a href="#" class="btn btn-primary" id="staff-view">Staff View</a>
-                        </div>
-                      </div>
-                    </div>`;
+                            <div class="card staff-button-card button-card" style="width: 18rem;">
+                              <div class="card-body middle" id="staff-view">
+                                <h5 class="card-title staff-title">Staff!</h5>
+                              </div>
+                            </div>
+                          </div>`;
 
 export default staffButton;

--- a/src/javascripts/components/staffButton.js
+++ b/src/javascripts/components/staffButton.js
@@ -1,9 +1,12 @@
-const staffButton = () => `<div id="staff-container" class="nav-cards-left">
-                            <div class="card staff-button-card button-card" style="width: 18rem;">
-                              <div class="card-body middle" id="staff-view">
-                                <h5 class="card-title staff-title">Staff!</h5>
-                              </div>
-                            </div>
-                          </div>`;
+const staffButton = () => `
+<div id="staff-container" class="nav-cards-left">
+  <div class="card staff-button-card button-card" style="width: 18rem;">
+    <div class="card-body middle">
+      <h5 class="card-title">Staff Card</h5>
+      <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+      <a href="#" class="btn btn-primary" id="staff-view">Staff View</a>
+    </div>
+  </div>
+</div>`;
 
 export default staffButton;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -60,6 +60,7 @@ footer {
   position: fixed;
   width: 100%;
   top: 0;
+  z-index: 9999;
 }
 #auth-button {
   margin-left: auto;

--- a/src/styles/staff.scss
+++ b/src/styles/staff.scss
@@ -1,1 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Alike&display=swap');
+
+.staff-button-card {
+  background-image: url('https://images.pexels.com/photos/1534134/pexels-photo-1534134.jpeg?auto=compress&cs=tinysrgb&dpr=1&w=500');
+}
+
+.staff-title {
+  color: white;
+  font-size: 2rem;
+}

--- a/src/styles/staff.scss
+++ b/src/styles/staff.scss
@@ -1,10 +1,1 @@
 @import url('https://fonts.googleapis.com/css2?family=Alike&display=swap');
-
-.staff-button-card {
-  background-image: url('https://images.pexels.com/photos/1534134/pexels-photo-1534134.jpeg?auto=compress&cs=tinysrgb&dpr=1&w=500');
-}
-
-.staff-title {
-  color: white;
-  font-size: 2rem;
-}


### PR DESCRIPTION
## Description
Fixed navbar's display so that cards do not display on top of navbar.

## Related Issue
#83 

## Motivation and Context
Every page displays the same way no overlapping contents over navbar.

## How Can This Be Tested?
git fetch cs-navbar-overlap
git checkout cs-navbar-overlap
npm start

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
