### PR TITLE
HMP souvenir hover fix

### DIFF
--- a/src/javascripts/components/printShows.js
+++ b/src/javascripts/components/printShows.js
@@ -7,7 +7,7 @@ const printShows = (array) => {
 
   array.forEach((show) => {
     const domString = `
-    <div class="card" id="shows-card--${show.firebaseKey}" style="width: 18rem;">
+    <div class="item card border-0 bg-transparent" id="shows-card--${show.firebaseKey}" style="width: 18rem;">
   <img src="${show.image}" class="card-img-top top" alt="show image">
   <div class="card-body-middle middle">
     <h5 class="card-title">${show.name}</h5>

--- a/src/javascripts/components/readOnlyPrinters/showFoodReadOnly.js
+++ b/src/javascripts/components/readOnlyPrinters/showFoodReadOnly.js
@@ -4,7 +4,7 @@ const showFoodReadOnly = (array) => {
   headerTitle('Food Shoppes');
   document.querySelector('#content-container').innerHTML = '';
   array.forEach((food) => {
-    const domString = `<div class="card food-card" style="width: 18rem;">
+    const domString = `<div class="food-card item card border-0 bg-transparent" style="width: 18rem;">
     <img src="${food.image}" class="card-img-top top" alt="...">
     <div class="card-body middle">
       <h5 class="card-title" id="food-card-title--${food.firebaseKey}">${food.name}</h5>

--- a/src/javascripts/components/readOnlyPrinters/showShowsReadOnly.js
+++ b/src/javascripts/components/readOnlyPrinters/showShowsReadOnly.js
@@ -5,7 +5,7 @@ const printShowsReadOnly = (array) => {
   document.querySelector('#content-container').innerHTML = '';
   array.forEach((show) => {
     const domString = `
-    <div class="card" id="shows-card--${show.firebaseKey}" style="width: 18rem;">
+    <div class="item card border-0 bg-transparent" id="shows-card--${show.firebaseKey}" style="width: 18rem;">
   <img src="${show.image}" class="card-img-top top" alt="show image">
   <div class="card-body-middle middle">
     <h5 class="card-title">${show.name}</h5>

--- a/src/javascripts/components/readOnlyPrinters/showSouvenirsReadOnly.js
+++ b/src/javascripts/components/readOnlyPrinters/showSouvenirsReadOnly.js
@@ -1,7 +1,7 @@
 const showSouvenirsReadOnly = (array) => {
   document.querySelector('#content-container').innerHTML = '';
   array.forEach((item) => {
-    document.querySelector('#content-container').innerHTML += `<div class="item">
+    document.querySelector('#content-container').innerHTML += `<div class="item card">
     <div class="souvenir-container m-3" style="width: 20rem">
       <img src='${item.souvenir_image}' class="card-img-top rounded mx-auto d-block top" id='card-img'></img>
       <div class="middle">

--- a/src/javascripts/components/readOnlyPrinters/showSouvenirsReadOnly.js
+++ b/src/javascripts/components/readOnlyPrinters/showSouvenirsReadOnly.js
@@ -1,7 +1,7 @@
 const showSouvenirsReadOnly = (array) => {
   document.querySelector('#content-container').innerHTML = '';
   array.forEach((item) => {
-    document.querySelector('#content-container').innerHTML += `<div class="item card">
+    document.querySelector('#content-container').innerHTML += `<div class="item card border-0 bg-transparent">
     <div class="souvenir-container m-3" style="width: 20rem">
       <img src='${item.souvenir_image}' class="card-img-top rounded mx-auto d-block top" id='card-img'></img>
       <div class="middle">

--- a/src/javascripts/components/readOnlyPrinters/showStaffReadOnly.js
+++ b/src/javascripts/components/readOnlyPrinters/showStaffReadOnly.js
@@ -2,7 +2,7 @@ const showStaffReadOnly = (array) => {
   document.querySelector('#content-container').innerHTML = '';
   array.forEach((item) => {
     document.querySelector('#content-container').innerHTML += `
-    <div id="staffContainer" class="card" style="width: 20rem;">
+    <div id="staffContainer" class="item card border-0 bg-transparent" style="width: 20rem;">
       <img class="card-img-top top pinImg" src="${item.staff_image}" alt="${item.first_name}">
       <div class="card-body staffInfo middle">
         <h5 class="card-title text-dark">${item.first_name}</h5>

--- a/src/javascripts/components/showFood.js
+++ b/src/javascripts/components/showFood.js
@@ -5,7 +5,7 @@ const showFood = (array) => {
   document.querySelector('#content-container').innerHTML = '';
   document.querySelector('#content-container').innerHTML = '<div class="create-food-btn" id="createFoodButton"><button type="button" class="btn btn-primary" id="create-food">Primary</button></div>';
   array.forEach((food) => {
-    const domString = `<div class="card food-card" style="width: 18rem;">
+    const domString = `<div class="food-card item card border-0 bg-transparent" style="width: 18rem;">
     <img src="${food.image}" class="card-img-top top" alt="...">
     <div class="card-body middle">
       <h5 class="card-title" id="food-card-title--${food.firebaseKey}">${food.name}</h5>

--- a/src/javascripts/components/showSouvenirs.js
+++ b/src/javascripts/components/showSouvenirs.js
@@ -1,7 +1,7 @@
 const showSouvenirs = (array) => {
   document.querySelector('#content-container').innerHTML = '<button class="btn btn-lg" id="add-souvenir-btn">Add A Souvenir</button>';
   array.forEach((item) => {
-    document.querySelector('#content-container').innerHTML += `<div class="item card m-3">
+    document.querySelector('#content-container').innerHTML += `<div class="item card border-0 bg-transparent">
     <div class="souvenir-container m-3" style="width: 20rem">
       <img src='${item.souvenir_image}' class="card-img-top rounded mx-auto d-block image top" id='card-img'></img>
       <div class="middle">

--- a/src/javascripts/components/showStaff.js
+++ b/src/javascripts/components/showStaff.js
@@ -3,7 +3,7 @@ const showStaff = (array) => {
   document.querySelector('#content-container').innerHTML = '<button class="btn btn-primary" id="add-newStaff-btn">Add A New Staff</button>';
   array.forEach((item) => {
     document.querySelector('#content-container').innerHTML += `
-    <div id="staffContainer" class="card" style="width: 20rem;">
+    <div id="staffContainer" class="item card border-0 bg-transparent" style="width: 20rem;">
       <img class="card-img-top pinImg top" src="${item.staff_image}" alt="${item.first_name}">
       <div class="card-body staffInfo middle">
         <h5 class="card-title text-dark">${item.first_name}</h5>

--- a/src/javascripts/components/souvenirButton.js
+++ b/src/javascripts/components/souvenirButton.js
@@ -2,7 +2,7 @@ const souvenirsButton = () => `<div id="souvenir-container" class="nav-cards">
                         <div class="card wares-button-card button-card" style="width: 18rem;">
                         <img src="src/assets/gandalfpipe.jpg" alt"Blue Marbled Pipe" class="image card-img-top rounded mx-auto d-block top" style="width:100%;">
                         <div class="card-body middle">
-                          <a href="#" class="btn" id="souvenir-view">Souvenirs</a>
+                          <a href="#" class="btn" id="souvenir-view"><h5>Souvenirs</h5></a>
                         </div>
                       </div>
                     </div>`;

--- a/src/styles/food.scss
+++ b/src/styles/food.scss
@@ -16,7 +16,7 @@
   border-radius: 10px;
   .card-title {
    font-size: 48px;
-   color: white;
+   color: #9DBE77;
   }
   .card-body {
     cursor: pointer;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -85,13 +85,15 @@ footer {
   width: 100%;
   opacity: 0;
   transition: .5s ease;
-  background-color:#CACACA;
-  color: #251617;
+  background-color: #1A1F14;
+  color: #9DBE77;
   font-weight: 700;
 }
 .card:hover .top {
   opacity: 0.3;
+  height: auto;
 }
 .card:hover .middle {
   opacity: 1;
+  height: auto;
 }

--- a/src/styles/souvenirs.scss
+++ b/src/styles/souvenirs.scss
@@ -21,3 +21,7 @@
 .souvenir-container {
   height: 30em;
 }
+#souvenir-view {
+  color: #9DBE77;
+  font-size: 48px;
+}


### PR DESCRIPTION
## Description
1. In read-only view, the souvenir cards were not displaying information on hover. I fixed that issue.
2. On each page, the cards contained an unsightly amount of white space, so I made the cards transparent and altered the margin + padding classes

## Related Issue
https://github.com/nss-evening-cohort-14/renaissance-fair-dashboard-renaissance-fair/issues/93

## Motivation and Context
It fixes an error in the read-only view. It also moves the project closer to resembling the wireframes.

## How Can This Be Tested?
git fetch
git checkout hmp-souvenir-hover-fix
npm start

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
