### PR TITLE
Update and delete events along with show, staff, food and souvenir selections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ User flow chart: ![flow-chart-ren](https://user-images.githubusercontent.com/761
 ## Deployed Netlify App [![Netlify Status](https://api.netlify.com/api/v1/badges/faa643b4-c3c3-4711-9204-b643023d960b/deploy-status)](https://app.netlify.com/sites/renfaire-v2/deploys)
 https://renfaire-v2.netlify.app
 ## Screenshots
- ## Loom Videos
+ ## Loom Video
 https://www.loom.com/share/d73f3f43131c45b5a71aab550186368c
 
 ![freelancer](https://user-images.githubusercontent.com/76187279/115093500-296ffc80-9ee0-11eb-9b7b-1095175b9c26.png)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ https://renfaire.netlify.app/
 # Freelancer Version 2
 
 ## Overview
-The second version of this app offers a new feature. The authenticated user can now add events. This feature allows the user to add food, souvenirs, staff, and shows from existing modules to their event. 
+The second version of this app offers a new feature. The authenticated user can now add, update and delete events. This feature allows the user to add food, souvenirs, staff, and shows from existing modules to their event. 
 
 ## Features
 1. A new events button on the nav bar for authenticated users

--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ User flow chart: ![flow-chart-ren](https://user-images.githubusercontent.com/761
 ## Deployed Netlify App [![Netlify Status](https://api.netlify.com/api/v1/badges/faa643b4-c3c3-4711-9204-b643023d960b/deploy-status)](https://app.netlify.com/sites/renfaire-v2/deploys)
 https://renfaire-v2.netlify.app
 ## Screenshots
+ ## Loom Videos
+https://www.loom.com/share/d73f3f43131c45b5a71aab550186368c
+
 ![freelancer](https://user-images.githubusercontent.com/76187279/115093500-296ffc80-9ee0-11eb-9b7b-1095175b9c26.png)
 
-![freelancer2](https://user-images.githubusercontent.com/76187279/115093504-2f65dd80-9ee0-11eb-90b4-a84483840eaa.png)
+![EventEdit](https://user-images.githubusercontent.com/51683901/115166332-43444780-a078-11eb-9023-71ad09a13758.PNG)
 
-![freelancer3](https://user-images.githubusercontent.com/76187279/115094361-dba8c380-9ee2-11eb-805a-c1d1d4e36633.png)
-
+![SingleEventView](https://user-images.githubusercontent.com/51683901/115166344-4dfedc80-a078-11eb-9430-a4ece4228512.PNG)
 ## Contributors 
 - John Maple: https://github.com/Greenfin17
 - Lindsey Satterfield: https://github.com/lindseysatterfield

--- a/json_sample_data/dashboards.json
+++ b/json_sample_data/dashboards.json
@@ -1,7 +1,0 @@
-{
-  "-MUuao2lynNljpuXaHnJ": {
-    "firebaseKey": "-MUuao2lynNljpuXaHnJ",
-    "title": "FirstDashboard",
-    "image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTasFiRvJUR02hfIal-kUGNYZrXRzLHxHJbLg&usqp=CAU"
-  }
-}

--- a/json_sample_data/events.json
+++ b/json_sample_data/events.json
@@ -1,0 +1,72 @@
+{
+  "-MYRx6B4HwgVcikFoybX" : {
+    "date" : "2021-06-08",
+    "firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "image" : "https://media.timeout.com/images/103945391/image.jpg",
+    "title" : "Faire Dancing",
+    "uid" : "kLFWBD6MHsPbcpfin2i2e67H2qq1"
+  },
+  "-MYS-pQ-q9ZsTNN77IA6" : {
+    "date" : "2021-08-04",
+    "firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "image" : "https://armstreet.com/pictures/blog/full/introduction-to-renaissance-fairs-we-answer-your-10-burning-questions.jpg",
+    "title" : "Rainbow Renaissance",
+    "uid" : "USZeMcTQCNSrAKBtbVITTpfOpzv2"
+  },
+  "-MYS0BJrk2ojS1FM8Bod" : {
+    "date" : "2021-05-29",
+    "firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "image" : "https://images.saymedia-content.com/.image/t_share/MTczOTQ5NDU4OTkwNzY5NDU5/a-complete-guide-to-the-renaissance-fair.jpg",
+    "title" : "Fire Faire",
+    "uid" : "FPshkFNEXuZxLMStP4xpAG24aLW2"
+  },
+  "-MYS0_VteGiAAf4sdVuq" : {
+    "date" : "2021-07-08",
+    "firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "image" : "https://bloximages.chicago2.vip.townnews.com/dailylocal.com/content/tncms/assets/v3/editorial/d/b1/db168bd7-d75b-5ec6-9198-292ab119b0c5/5b7c67ad1c464.image.jpg?resize=1200%2C699",
+    "title" : "Turkey Leg Eating Faire",
+    "uid" : "FPshkFNEXuZxLMStP4xpAG24aLW2"
+  },
+  "-MYS0afPkXfejYV6eFRa" : {
+    "date" : "2021-07-18",
+    "firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "image" : "https://www.visitflorenceal.com/imager/s3_us-east-1_amazonaws_com/florence-2019/images/local-business-images/faire_06c0c6a6d9234a48cbd7dc4352fe72e0.jpg",
+    "title" : "Tennessee Renaissance Fair",
+    "uid" : "FPshkFNEXuZxLMStP4xpAG24aLW2"
+  },
+  "-MYS0v3qmXBLjlAcpr5j" : {
+    "date" : "2021-09-21",
+    "firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "image" : "https://s7d2.scene7.com/is/image/TWCNews/011220_n13-brevard-renaissance-fair-file",
+    "title" : "Jousting",
+    "uid" : "FPshkFNEXuZxLMStP4xpAG24aLW2"
+  },
+  "-MYS2DrArfOomKxsEPn2" : {
+    "date" : "2021-06-29",
+    "firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "image" : "https://www.gannett-cdn.com/presto/2020/09/17/NSHT/5bedea6b-a4a5-41b4-a03d-83ad2bfb3ac8-Female_Knight_.jpg",
+    "title" : "Tennessee Fair",
+    "uid" : "FPshkFNEXuZxLMStP4xpAG24aLW2"
+  },
+  "-MYSBHf-jV_yTvMZTVz8" : {
+    "date" : "2021-07-05",
+    "firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "image" : "https://njfamily-images.s3.us-east-1.amazonaws.com/wp-content/uploads/2019/04/0-1.jpg",
+    "title" : "Kentucky Renaissance Fair",
+    "uid" : "FPshkFNEXuZxLMStP4xpAG24aLW2"
+  },
+  "-MYT-BafTnkwBY-UdfWH" : {
+    "date" : "2021-07-23",
+    "firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "image" : "https://9gho4spu9j-flywheel.netdna-ssl.com/wp-content/uploads/2019/12/Golondrinas_home-slider_2020-Ren1.jpg",
+    "title" : "Tennessee Renaissance Fair",
+    "uid" : "FPshkFNEXuZxLMStP4xpAG24aLW2"
+  },
+  "-MYV5rpei5Cm_F7oGOA9" : {
+    "date" : "2021-04-20",
+    "firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "image" : "https://renfair.com/socal/wp-content/uploads/sites/2/2016/02/photo5.jpg",
+    "title" : "Fairie Land Adventures",
+    "uid" : "USZeMcTQCNSrAKBtbVITTpfOpzv2"
+  }
+}

--- a/json_sample_data/events_food.json
+++ b/json_sample_data/events_food.json
@@ -1,0 +1,240 @@
+{
+  "-MYT17pFfSXS8yMJSao9" : {
+    "event_firebaseKey" : "-MYT17jpQVnnA9H3jWYZ",
+    "firebaseKey" : "-MYT17pFfSXS8yMJSao9",
+    "food_firebaseKey" : "-MVqxNr0wVophcLKgolo"
+  },
+  "-MYT17pXjUu3_Wsx85fj" : {
+    "event_firebaseKey" : "-MYT17jpQVnnA9H3jWYZ",
+    "firebaseKey" : "-MYT17pXjUu3_Wsx85fj",
+    "food_firebaseKey" : "-MVqxNr2P3K2XSNYcnhH"
+  },
+  "-MYTpcI69pl-o6Q_M4H-" : {
+    "count" : 30,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcI69pl-o6Q_M4H-",
+    "food_firebaseKey" : "-MVqxNqxoNTgbacrgc_W"
+  },
+  "-MYTpcIHGJKTndjSZJHV" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcIHGJKTndjSZJHV",
+    "food_firebaseKey" : "-MVqxNqzjWxKXeC6lbs2"
+  },
+  "-MYTpcIPXb8pf681PLV0" : {
+    "count" : 25,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcIPXb8pf681PLV0",
+    "food_firebaseKey" : "-MVqxNr0wVophcLKgolo"
+  },
+  "-MYTpcIcXrGEFLPckTDu" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcIcXrGEFLPckTDu",
+    "food_firebaseKey" : "-MVqxNr2P3K2XSNYcnhH"
+  },
+  "-MYTpcIjoe5tA33U1HRu" : {
+    "count" : 35,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcIjoe5tA33U1HRu",
+    "food_firebaseKey" : "-MVqxNr4OrvYigAth_eb"
+  },
+  "-MYTpxhRM3dEvYcc4W_k" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxhRM3dEvYcc4W_k",
+    "food_firebaseKey" : "-MVqxNqxoNTgbacrgc_W"
+  },
+  "-MYTpxh_D-nMPuv_KTKU" : {
+    "count" : 200,
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxh_D-nMPuv_KTKU",
+    "food_firebaseKey" : "-MVqxNqzjWxKXeC6lbs2"
+  },
+  "-MYTpxhjRzfDpuYQfTGV" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxhjRzfDpuYQfTGV",
+    "food_firebaseKey" : "-MVqxNr0wVophcLKgolo"
+  },
+  "-MYTpxhrwnUlgEAJ90eO" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxhrwnUlgEAJ90eO",
+    "food_firebaseKey" : "-MVqxNr74tqCjRkC_V9H"
+  },
+  "-MYTpxiUKxZcN8SI_kv6" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxiUKxZcN8SI_kv6",
+    "food_firebaseKey" : "-MVqxNr9L_9VM_ScMj6R"
+  },
+  "-MYTuibsMdpQBjj9HzQ9" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuibsMdpQBjj9HzQ9",
+    "food_firebaseKey" : "-MVqxNqxoNTgbacrgc_W"
+  },
+  "-MYTuic2c5Y9GuamSqXb" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuic2c5Y9GuamSqXb",
+    "food_firebaseKey" : "-MVqxNqzjWxKXeC6lbs2"
+  },
+  "-MYTuicBj2SRZcsLG7v-" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuicBj2SRZcsLG7v-",
+    "food_firebaseKey" : "-MVqxNr0wVophcLKgolo"
+  },
+  "-MYTv0m0o6AAsOKdCmJi" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0m0o6AAsOKdCmJi",
+    "food_firebaseKey" : "-MVqxNqxoNTgbacrgc_W"
+  },
+  "-MYTv0m8mYoDJqSTVaBX" : {
+    "count" : 200,
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0m8mYoDJqSTVaBX",
+    "food_firebaseKey" : "-MVqxNqzjWxKXeC6lbs2"
+  },
+  "-MYTv0mLgkDcV-afWKRY" : {
+    "count" : 120,
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0mLgkDcV-afWKRY",
+    "food_firebaseKey" : "-MVqxNr0wVophcLKgolo"
+  },
+  "-MYTw6Fp3BpDca_4aeBz" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6Fp3BpDca_4aeBz",
+    "food_firebaseKey" : "-MVqxNqxoNTgbacrgc_W"
+  },
+  "-MYTw6FyDws-vqYnt1pk" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6FyDws-vqYnt1pk",
+    "food_firebaseKey" : "-MVqxNqzjWxKXeC6lbs2"
+  },
+  "-MYTw6GCONrMivnFiBBP" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6GCONrMivnFiBBP",
+    "food_firebaseKey" : "-MVqxNr0wVophcLKgolo"
+  },
+  "-MYTwBETVcZ9WOH8Dv80" : {
+    "count" : 180,
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBETVcZ9WOH8Dv80",
+    "food_firebaseKey" : "-MVqxNqxoNTgbacrgc_W"
+  },
+  "-MYTwBEkHH_HrgD3TB0j" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBEkHH_HrgD3TB0j",
+    "food_firebaseKey" : "-MVqxNr0wVophcLKgolo"
+  },
+  "-MYTwBEzzzQGG2Bq2n62" : {
+    "count" : 80,
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBEzzzQGG2Bq2n62",
+    "food_firebaseKey" : "-MVqxNr4OrvYigAth_eb"
+  },
+  "-MYTwBFA1t2CoWre6r1s" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBFA1t2CoWre6r1s",
+    "food_firebaseKey" : "-MVqxNr74tqCjRkC_V9H"
+  },
+  "-MYTwVpvF7K7sGJo15BA" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVpvF7K7sGJo15BA",
+    "food_firebaseKey" : "-MVqxNr74tqCjRkC_V9H"
+  },
+  "-MYTwVq-hMRxdGefN-dr" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVq-hMRxdGefN-dr",
+    "food_firebaseKey" : "-MVqxNr9L_9VM_ScMj6R"
+  },
+  "-MYTwVq6PuotypcFIL8L" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVq6PuotypcFIL8L",
+    "food_firebaseKey" : "-MVqxNrEduzMS9XvYbbA"
+  },
+  "-MYVBXuMa1_fbR48aVtj" : {
+    "count" : 250,
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXuMa1_fbR48aVtj",
+    "food_firebaseKey" : "-MVqxNrB0w4QXvgBr_Zj"
+  },
+  "-MYVBXuPmi0aO7Slwv_7" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXuPmi0aO7Slwv_7",
+    "food_firebaseKey" : "-MVqxNrEduzMS9XvYbbA"
+  },
+  "-MYVJuyfDDTZy-Zd5Tlb" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuyfDDTZy-Zd5Tlb",
+    "food_firebaseKey" : "-MVqxNqxoNTgbacrgc_W"
+  },
+  "-MYVJuzGatnW9eh5lnbd" : {
+    "count" : 27,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuzGatnW9eh5lnbd",
+    "food_firebaseKey" : "-MVqxNr0wVophcLKgolo"
+  },
+  "-MYVJuzS9AaP4DUQ4Tys" : {
+    "count" : 200,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuzS9AaP4DUQ4Tys",
+    "food_firebaseKey" : "-MVqxNr2P3K2XSNYcnhH"
+  },
+  "-MYVJuzVCoiDiploZbdC" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuzVCoiDiploZbdC",
+    "food_firebaseKey" : "-MVqxNrB0w4QXvgBr_Zj"
+  },
+  "-MYVJuzsd-5WE2T9DC7H" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuzsd-5WE2T9DC7H",
+    "food_firebaseKey" : "-MVqxNqzjWxKXeC6lbs2"
+  },
+  "-MYVJuzx0XJ3FsUSN3w3" : {
+    "count" : 25,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuzx0XJ3FsUSN3w3",
+    "food_firebaseKey" : "-MVqxNrEduzMS9XvYbbA"
+  },
+  "-MYVJv-2iK2qE9DZlR2s" : {
+    "count" : 25,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJv-2iK2qE9DZlR2s",
+    "food_firebaseKey" : "-MVqxNrHhO8NRulKEu00"
+  },
+  "-MYbUXpefrZXi77aI1nG" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXpefrZXi77aI1nG",
+    "food_firebaseKey" : "-MVqxNqxoNTgbacrgc_W"
+  },
+  "-MYbUXplYwbsRyw_MASY" : {
+    "count" : 20,
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXplYwbsRyw_MASY",
+    "food_firebaseKey" : "-MVqxNr0wVophcLKgolo"
+  },
+  "-MYbUXpmtZbouOeTNASg" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXpmtZbouOeTNASg",
+    "food_firebaseKey" : "-MVqxNqzjWxKXeC6lbs2"
+  }
+}

--- a/json_sample_data/events_shows.json
+++ b/json_sample_data/events_shows.json
@@ -1,0 +1,217 @@
+{
+  "-MYT17oUvjNHDo220_sO" : {
+    "event_firebaseKey" : "-MYT17jpQVnnA9H3jWYZ",
+    "firebaseKey" : "-MYT17oUvjNHDo220_sO",
+    "show_firebaseKey" : "-MW6Y96LBUFZEhnr5UrA"
+  },
+  "-MYT17orLw8oS2HbyqlO" : {
+    "event_firebaseKey" : "-MYT17jpQVnnA9H3jWYZ",
+    "firebaseKey" : "-MYT17orLw8oS2HbyqlO",
+    "show_firebaseKey" : "-MW6Yew43S2eiLaGrUmr"
+  },
+  "-MYTpcGnaR4KVc4uyydZ" : {
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcGnaR4KVc4uyydZ",
+    "show_firebaseKey" : "-MW6U7ptyGymUBEkVJ_X"
+  },
+  "-MYTpcGvvK0swacPc2lb" : {
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcGvvK0swacPc2lb",
+    "show_firebaseKey" : "-MW6XfQed8lwUl-fFws1"
+  },
+  "-MYTpcH8e__Uftv0a0Mp" : {
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcH8e__Uftv0a0Mp",
+    "show_firebaseKey" : "-MW6WAfWIj6GUI9lQthz"
+  },
+  "-MYTpcHH8yVWZ-mqUkVo" : {
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcHH8yVWZ-mqUkVo",
+    "show_firebaseKey" : "-MW6Y96LBUFZEhnr5UrA"
+  },
+  "-MYTpcHRuDgUyLKNdPRt" : {
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcHRuDgUyLKNdPRt",
+    "show_firebaseKey" : "-MW6Yew43S2eiLaGrUmr"
+  },
+  "-MYTpxfp0taeoVb56YQ5" : {
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxfp0taeoVb56YQ5",
+    "show_firebaseKey" : "-MW6Yew43S2eiLaGrUmr"
+  },
+  "-MYTpxg6IhwGFTCpisqN" : {
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxg6IhwGFTCpisqN",
+    "show_firebaseKey" : "-MW6YwQKsQ4hnNYDoEOC"
+  },
+  "-MYTpxgHwanuP3oCJ5Ky" : {
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxgHwanuP3oCJ5Ky",
+    "show_firebaseKey" : "-MYCYcmEfs017WI1INjX"
+  },
+  "-MYTpxgYYBIxl1oTipK1" : {
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxgYYBIxl1oTipK1",
+    "show_firebaseKey" : "-MW6WAfWIj6GUI9lQthz"
+  },
+  "-MYTuia7Y3mUGfVsy2Ih" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuia7Y3mUGfVsy2Ih",
+    "show_firebaseKey" : "-MW6U7ptyGymUBEkVJ_X"
+  },
+  "-MYTuiaD-cEUkt-UcM3l" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuiaD-cEUkt-UcM3l",
+    "show_firebaseKey" : "-MW6WAfWIj6GUI9lQthz"
+  },
+  "-MYTuiaEnByZQiB200YH" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuiaEnByZQiB200YH",
+    "show_firebaseKey" : "-MW6VnIg6ke6Qs6rLA9y"
+  },
+  "-MYTuiaIJtMbjqTIKXNm" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuiaIJtMbjqTIKXNm",
+    "show_firebaseKey" : "-MW6Ws0hRa-NZE1Qbnh7"
+  },
+  "-MYTv0kWa7vDRPnj2Msd" : {
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0kWa7vDRPnj2Msd",
+    "show_firebaseKey" : "-MW6VnIg6ke6Qs6rLA9y"
+  },
+  "-MYTv0kexZAlucCI4sGU" : {
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0kexZAlucCI4sGU",
+    "show_firebaseKey" : "-MW6WAfWIj6GUI9lQthz"
+  },
+  "-MYTv0kuzBnqzL9DgVY-" : {
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0kuzBnqzL9DgVY-",
+    "show_firebaseKey" : "-MW6Y96LBUFZEhnr5UrA"
+  },
+  "-MYTv0kxgrVqk4lO5SxV" : {
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0kxgrVqk4lO5SxV",
+    "show_firebaseKey" : "-MW6Yew43S2eiLaGrUmr"
+  },
+  "-MYTw6FQr0w18QWDzBm-" : {
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6FQr0w18QWDzBm-",
+    "show_firebaseKey" : "-MW6VnIg6ke6Qs6rLA9y"
+  },
+  "-MYTw6FR-bllwwXXISjC" : {
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6FR-bllwwXXISjC",
+    "show_firebaseKey" : "-MW6U7ptyGymUBEkVJ_X"
+  },
+  "-MYTwBDYJa87JrEkszgs" : {
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBDYJa87JrEkszgs",
+    "show_firebaseKey" : "-MW6U7ptyGymUBEkVJ_X"
+  },
+  "-MYTwBDdRAaU2YXJalmo" : {
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBDdRAaU2YXJalmo",
+    "show_firebaseKey" : "-MW6VnIg6ke6Qs6rLA9y"
+  },
+  "-MYTwBDoCvx42gUgkFju" : {
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBDoCvx42gUgkFju",
+    "show_firebaseKey" : "-MW6WAfWIj6GUI9lQthz"
+  },
+  "-MYTwVoDlwN2QU21Bi85" : {
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVoDlwN2QU21Bi85",
+    "show_firebaseKey" : "-MW6U7ptyGymUBEkVJ_X"
+  },
+  "-MYTwVokh5QJjyptWG19" : {
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVokh5QJjyptWG19",
+    "show_firebaseKey" : "-MW6VnIg6ke6Qs6rLA9y"
+  },
+  "-MYTwVovD2j_c34LNdFp" : {
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVovD2j_c34LNdFp",
+    "show_firebaseKey" : "-MW6WAfWIj6GUI9lQthz"
+  },
+  "-MYTwVoxpUN16ZeTJZfn" : {
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVoxpUN16ZeTJZfn",
+    "show_firebaseKey" : "-MW6XfQed8lwUl-fFws1"
+  },
+  "-MYTwVpEN6530Zw3hHQD" : {
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVpEN6530Zw3hHQD",
+    "show_firebaseKey" : "-MW6Y96LBUFZEhnr5UrA"
+  },
+  "-MYVBXsvTvnBt23wPBgc" : {
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXsvTvnBt23wPBgc",
+    "show_firebaseKey" : "-MW6U7ptyGymUBEkVJ_X"
+  },
+  "-MYVBXsvTvnBt23wPBgd" : {
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXsvTvnBt23wPBgd",
+    "show_firebaseKey" : "-MW6VnIg6ke6Qs6rLA9y"
+  },
+  "-MYVBXtSD_f5WnxWhgUV" : {
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXtSD_f5WnxWhgUV",
+    "show_firebaseKey" : "-MW6XK8xmtlEycbP3OwQ"
+  },
+  "-MYVBXtZuh4RdxY1oQwR" : {
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXtZuh4RdxY1oQwR",
+    "show_firebaseKey" : "-MW6YwQKsQ4hnNYDoEOC"
+  },
+  "-MYVBXtcJLf0nQF8BDxD" : {
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXtcJLf0nQF8BDxD",
+    "show_firebaseKey" : "-MW6Yew43S2eiLaGrUmr"
+  },
+  "-MYVJuwB8FmQ-NeiCPyj" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuwB8FmQ-NeiCPyj",
+    "show_firebaseKey" : "-MW6VnIg6ke6Qs6rLA9y"
+  },
+  "-MYVJuwpPwD3exwLVvWU" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuwpPwD3exwLVvWU",
+    "show_firebaseKey" : "-MW6WAfWIj6GUI9lQthz"
+  },
+  "-MYVJux1hcrVmd56rcyC" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJux1hcrVmd56rcyC",
+    "show_firebaseKey" : "-MW6YwQKsQ4hnNYDoEOC"
+  },
+  "-MYVJux_7oy-eIg8EaaA" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJux_7oy-eIg8EaaA",
+    "show_firebaseKey" : "-MYCYcmEfs017WI1INjX"
+  },
+  "-MYbUXnO-ejUGF_J-Wi6" : {
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXnO-ejUGF_J-Wi6",
+    "show_firebaseKey" : "-MW6VnIg6ke6Qs6rLA9y"
+  },
+  "-MYbUXoHM-D5_tjzYGHX" : {
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXoHM-D5_tjzYGHX",
+    "show_firebaseKey" : "-MW6Yew43S2eiLaGrUmr"
+  },
+  "-MYbUXoIjS3Na6LFJKIi" : {
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXoIjS3Na6LFJKIi",
+    "show_firebaseKey" : "-MW6WAfWIj6GUI9lQthz"
+  },
+  "-MYbUXoUmCqG3EKD6TP0" : {
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXoUmCqG3EKD6TP0",
+    "show_firebaseKey" : "-MW6XfQed8lwUl-fFws1"
+  },
+  "-MYbUXpdGt7jFMr1mzDZ" : {
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXpdGt7jFMr1mzDZ",
+    "show_firebaseKey" : "-MW6YwQKsQ4hnNYDoEOC"
+  }
+}

--- a/json_sample_data/events_souvenirs.json
+++ b/json_sample_data/events_souvenirs.json
@@ -1,0 +1,264 @@
+{
+  "-MYT17olWs4EnLBaPDyv" : {
+    "event_firebaseKey" : "-MYT17jpQVnnA9H3jWYZ",
+    "firebaseKey" : "-MYT17olWs4EnLBaPDyv",
+    "souvenir_firebaseKey" : "-MVnp0LjWmmJdI2Uj-kd"
+  },
+  "-MYT17opIp2tSFy8z_Fo" : {
+    "event_firebaseKey" : "-MYT17jpQVnnA9H3jWYZ",
+    "firebaseKey" : "-MYT17opIp2tSFy8z_Fo",
+    "souvenir_firebaseKey" : "-MYHdrRUxvMEuU9PY0LX"
+  },
+  "-MYTpcFyQhRxwpcJn4V5" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcFyQhRxwpcJn4V5",
+    "souvenir_firebaseKey" : "-MVnbU8VwoHVXcWscrrQ"
+  },
+  "-MYTpcG4T169BYBzUwAW" : {
+    "count" : 30,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcG4T169BYBzUwAW",
+    "souvenir_firebaseKey" : "-MVndERf6PlFfusGKN2i"
+  },
+  "-MYTpcGN6AiB_BDIophN" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcGN6AiB_BDIophN",
+    "souvenir_firebaseKey" : "-MVnkrRDIBgBMyA1m6Ax"
+  },
+  "-MYTpcGO95XZA0i0OV7F" : {
+    "count" : 25,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcGO95XZA0i0OV7F",
+    "souvenir_firebaseKey" : "-MVnhhGTf8Ygx01P4iWQ"
+  },
+  "-MYTpcGZbbB0vYM2ah9_" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcGZbbB0vYM2ah9_",
+    "souvenir_firebaseKey" : "-MVnn6PwrmHC_3a5UQFS"
+  },
+  "-MYTpcGh7hAxuq3azRT_" : {
+    "count" : 25,
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcGh7hAxuq3azRT_",
+    "souvenir_firebaseKey" : "-MVnp0LjWmmJdI2Uj-kd"
+  },
+  "-MYTpxfPsLemizrdeONJ" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxfPsLemizrdeONJ",
+    "souvenir_firebaseKey" : "-MVndERf6PlFfusGKN2i"
+  },
+  "-MYTpxfTgh1f1qeHrKip" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxfTgh1f1qeHrKip",
+    "souvenir_firebaseKey" : "-MVnfLMclD-h0_3C2qy3"
+  },
+  "-MYTpxfX8MzxhFCpRWIs" : {
+    "count" : 200,
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxfX8MzxhFCpRWIs",
+    "souvenir_firebaseKey" : "-MVnhhGTf8Ygx01P4iWQ"
+  },
+  "-MYTpxfeDns0bDll_m1n" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxfeDns0bDll_m1n",
+    "souvenir_firebaseKey" : "-MVnp0LjWmmJdI2Uj-kd"
+  },
+  "-MYTuiZmYtb00ysWMK0D" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuiZmYtb00ysWMK0D",
+    "souvenir_firebaseKey" : "-MVnbU8VwoHVXcWscrrQ"
+  },
+  "-MYTuiZvn-eq-cJdk4NN" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuiZvn-eq-cJdk4NN",
+    "souvenir_firebaseKey" : "-MVndERf6PlFfusGKN2i"
+  },
+  "-MYTuiZxLgKY1qQaTUgR" : {
+    "count" : 120,
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuiZxLgKY1qQaTUgR",
+    "souvenir_firebaseKey" : "-MVnjlKvzRVVKsoz0dWg"
+  },
+  "-MYTui_2TLeCLZb-pp8q" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTui_2TLeCLZb-pp8q",
+    "souvenir_firebaseKey" : "-MVnfLMclD-h0_3C2qy3"
+  },
+  "-MYTuia-i2888f3wzqn7" : {
+    "count" : 2000,
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuia-i2888f3wzqn7",
+    "souvenir_firebaseKey" : "-MYHdrRUxvMEuU9PY0LX"
+  },
+  "-MYTuia0wl63Lf3lkGzV" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuia0wl63Lf3lkGzV",
+    "souvenir_firebaseKey" : "-MVnkrRDIBgBMyA1m6Ax"
+  },
+  "-MYTv0k7nKH8NdMZPnjZ" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0k7nKH8NdMZPnjZ",
+    "souvenir_firebaseKey" : "-MVndERf6PlFfusGKN2i"
+  },
+  "-MYTv0kBV_nI_qkNQXY3" : {
+    "count" : 150,
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0kBV_nI_qkNQXY3",
+    "souvenir_firebaseKey" : "-MVnfLMclD-h0_3C2qy3"
+  },
+  "-MYTv0kYvBGmUHAUNhA0" : {
+    "count" : 120,
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0kYvBGmUHAUNhA0",
+    "souvenir_firebaseKey" : "-MVnp0LjWmmJdI2Uj-kd"
+  },
+  "-MYTw6Evhtkr6r2_iobc" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6Evhtkr6r2_iobc",
+    "souvenir_firebaseKey" : "-MVndERf6PlFfusGKN2i"
+  },
+  "-MYTw6EwGWnFkz_gRd_x" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6EwGWnFkz_gRd_x",
+    "souvenir_firebaseKey" : "-MVnbU8VwoHVXcWscrrQ"
+  },
+  "-MYTw6F33r0vzHcWcyPp" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6F33r0vzHcWcyPp",
+    "souvenir_firebaseKey" : "-MVnfLMclD-h0_3C2qy3"
+  },
+  "-MYTwBCuCyLNpqTIoOcL" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBCuCyLNpqTIoOcL",
+    "souvenir_firebaseKey" : "-MVndERf6PlFfusGKN2i"
+  },
+  "-MYTwBCxsp2w6n7O57NR" : {
+    "count" : 100,
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBCxsp2w6n7O57NR",
+    "souvenir_firebaseKey" : "-MVnhhGTf8Ygx01P4iWQ"
+  },
+  "-MYTwBD9NQsOcs-le1td" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBD9NQsOcs-le1td",
+    "souvenir_firebaseKey" : "-MVnfLMclD-h0_3C2qy3"
+  },
+  "-MYTwBDoCvx42gUgkFjv" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBDoCvx42gUgkFjv",
+    "souvenir_firebaseKey" : "-MVniWGtwTOMp6n4FW75"
+  },
+  "-MYTwVnwH7WLxDTaZLSP" : {
+    "count" : 75,
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVnwH7WLxDTaZLSP",
+    "souvenir_firebaseKey" : "-MVndERf6PlFfusGKN2i"
+  },
+  "-MYTwVo6dQUfbWlfM1cG" : {
+    "count" : 125,
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVo6dQUfbWlfM1cG",
+    "souvenir_firebaseKey" : "-MVniWGtwTOMp6n4FW75"
+  },
+  "-MYTwVo6dQUfbWlfM1cH" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVo6dQUfbWlfM1cH",
+    "souvenir_firebaseKey" : "-MVnfLMclD-h0_3C2qy3"
+  },
+  "-MYTwVoDlwN2QU21Bi86" : {
+    "count" : 200,
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVoDlwN2QU21Bi86",
+    "souvenir_firebaseKey" : "-MVnhhGTf8Ygx01P4iWQ"
+  },
+  "-MYVBXsR1v-Mv20sWxiB" : {
+    "count" : 20,
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXsR1v-Mv20sWxiB",
+    "souvenir_firebaseKey" : "-MVnfLMclD-h0_3C2qy3"
+  },
+  "-MYVBXscLjeGNQ_qbFmp" : {
+    "count" : 5,
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXscLjeGNQ_qbFmp",
+    "souvenir_firebaseKey" : "-MVnhhGTf8Ygx01P4iWQ"
+  },
+  "-MYVBXsiN2fSy1EI2hjO" : {
+    "count" : 0,
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXsiN2fSy1EI2hjO",
+    "souvenir_firebaseKey" : "-MVnn6PwrmHC_3a5UQFS"
+  },
+  "-MYVBXsjFiZ49YmbI65U" : {
+    "count" : 0,
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXsjFiZ49YmbI65U",
+    "souvenir_firebaseKey" : "-MVnp0LjWmmJdI2Uj-kd"
+  },
+  "-MYVBXtGEk0bMVOGEkVs" : {
+    "count" : 0,
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXtGEk0bMVOGEkVs",
+    "souvenir_firebaseKey" : "-MYHdrRUxvMEuU9PY0LX"
+  },
+  "-MYVJuvNZEfreSHLhnu1" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuvNZEfreSHLhnu1",
+    "souvenir_firebaseKey" : "-MVniWGtwTOMp6n4FW75"
+  },
+  "-MYVJuw4VJzmkf55VOaD" : {
+    "count" : 25,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuw4VJzmkf55VOaD",
+    "souvenir_firebaseKey" : "-MVnjlKvzRVVKsoz0dWg"
+  },
+  "-MYVJv1_DUMjvM1tJlCx" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJv1_DUMjvM1tJlCx",
+    "souvenir_firebaseKey" : "-MVnkrRDIBgBMyA1m6Ax"
+  },
+  "-MYVJv1gJGtU2WkDvQT9" : {
+    "count" : 1000,
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJv1gJGtU2WkDvQT9",
+    "souvenir_firebaseKey" : "-MYHdrRUxvMEuU9PY0LX"
+  },
+  "-MYbUXmNIxsS9MQy8KRa" : {
+    "count" : 50,
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXmNIxsS9MQy8KRa",
+    "souvenir_firebaseKey" : "-MVnbU8VwoHVXcWscrrQ"
+  },
+  "-MYbUXn_mtq-7vCE7IHa" : {
+    "count" : 25,
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXn_mtq-7vCE7IHa",
+    "souvenir_firebaseKey" : "-MVndERf6PlFfusGKN2i"
+  },
+  "-MYbUXn_mtq-7vCE7IHb" : {
+    "count" : 500,
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXn_mtq-7vCE7IHb",
+    "souvenir_firebaseKey" : "-MVnhhGTf8Ygx01P4iWQ"
+  }
+}

--- a/json_sample_data/events_staff.json
+++ b/json_sample_data/events_staff.json
@@ -1,0 +1,222 @@
+{
+  "-MYT17owNtvanxTnPpS5" : {
+    "event_firebaseKey" : "-MYT17jpQVnnA9H3jWYZ",
+    "firebaseKey" : "-MYT17owNtvanxTnPpS5",
+    "staff_firebaseKey" : "-MYHdWhKUDHttCn27Grs"
+  },
+  "-MYT17pFfSXS8yMJSaoA" : {
+    "event_firebaseKey" : "-MYT17jpQVnnA9H3jWYZ",
+    "firebaseKey" : "-MYT17pFfSXS8yMJSaoA",
+    "staff_firebaseKey" : "-MYHdz3jNz3bUHimldxA"
+  },
+  "-MYTpcH_2oxaqCirum57" : {
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcH_2oxaqCirum57",
+    "staff_firebaseKey" : "-CSNFup34oXLq9bbdXnk"
+  },
+  "-MYTpcHe44NeWNb5Gtx_" : {
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcHe44NeWNb5Gtx_",
+    "staff_firebaseKey" : "-CSCPwAIAg2hTA1XULGc"
+  },
+  "-MYTpcHpnCCitmSth2hY" : {
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcHpnCCitmSth2hY",
+    "staff_firebaseKey" : "-CSQxSoGKznGShFypOJz"
+  },
+  "-MYTpcHxHh5uFJr2Ovkt" : {
+    "event_firebaseKey" : "-MYS0BJrk2ojS1FM8Bod",
+    "firebaseKey" : "-MYTpcHxHh5uFJr2Ovkt",
+    "staff_firebaseKey" : "-CSRCLIYxRDnnOOC2G2Q"
+  },
+  "-MYTpxge9iwF56X2ahSZ" : {
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxge9iwF56X2ahSZ",
+    "staff_firebaseKey" : "-CSCPwAIAg2hTA1XULGc"
+  },
+  "-MYTpxggcjUITcmAqZHv" : {
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxggcjUITcmAqZHv",
+    "staff_firebaseKey" : "-CS8TBPUiwbjKRhvG5Uz"
+  },
+  "-MYTpxgkPzu3bwnBN7Wl" : {
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxgkPzu3bwnBN7Wl",
+    "staff_firebaseKey" : "-CSQxSoGKznGShFypOJz"
+  },
+  "-MYTpxgxyOSGnYaktTWw" : {
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxgxyOSGnYaktTWw",
+    "staff_firebaseKey" : "-CSRCLIYxRDnnOOC2G2Q"
+  },
+  "-MYTpxhOd_FSva_qFi3t" : {
+    "event_firebaseKey" : "-MYS0_VteGiAAf4sdVuq",
+    "firebaseKey" : "-MYTpxhOd_FSva_qFi3t",
+    "staff_firebaseKey" : "-CSXBfLa27HeEHN3iIEp"
+  },
+  "-MYTuib-Ca30dRuaqiKL" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuib-Ca30dRuaqiKL",
+    "staff_firebaseKey" : "-CS8TBPUiwbjKRhvG5Uz"
+  },
+  "-MYTuib1Siyp3G19VS5Z" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuib1Siyp3G19VS5Z",
+    "staff_firebaseKey" : "-CSNFup34oXLq9bbdXnk"
+  },
+  "-MYTuibHyJhTeSFufMDr" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuibHyJhTeSFufMDr",
+    "staff_firebaseKey" : "-CSQxSoGKznGShFypOJz"
+  },
+  "-MYTuibIiJGtJG_XSQ4p" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuibIiJGtJG_XSQ4p",
+    "staff_firebaseKey" : "-CSXBfLa27HeEHN3iIEp"
+  },
+  "-MYTuibX4aGm-WPBUN-z" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuibX4aGm-WPBUN-z",
+    "staff_firebaseKey" : "-MYHdWhKUDHttCn27Grs"
+  },
+  "-MYTuibeQFmP7MGGJNvj" : {
+    "event_firebaseKey" : "-MYS0afPkXfejYV6eFRa",
+    "firebaseKey" : "-MYTuibeQFmP7MGGJNvj",
+    "staff_firebaseKey" : "-MYHdz3jNz3bUHimldxA"
+  },
+  "-MYTv0l4zTUyDJUvdIwh" : {
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0l4zTUyDJUvdIwh",
+    "staff_firebaseKey" : "-CS8TBPUiwbjKRhvG5Uz"
+  },
+  "-MYTv0lJgGuYUaPuNC9J" : {
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0lJgGuYUaPuNC9J",
+    "staff_firebaseKey" : "-CSNFup34oXLq9bbdXnk"
+  },
+  "-MYTv0lSYfrm9D4YdxFs" : {
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0lSYfrm9D4YdxFs",
+    "staff_firebaseKey" : "-CSCPwAIAg2hTA1XULGc"
+  },
+  "-MYTv0lb5TRlDpGlp1Uq" : {
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0lb5TRlDpGlp1Uq",
+    "staff_firebaseKey" : "-CSdP5J71Trra6tpmuDl"
+  },
+  "-MYTv0lngQQgqMNCXKD5" : {
+    "event_firebaseKey" : "-MYS2DrArfOomKxsEPn2",
+    "firebaseKey" : "-MYTv0lngQQgqMNCXKD5",
+    "staff_firebaseKey" : "-MYHdWhKUDHttCn27Grs"
+  },
+  "-MYTw6FWzanOjGu1c2in" : {
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6FWzanOjGu1c2in",
+    "staff_firebaseKey" : "-CSCPwAIAg2hTA1XULGc"
+  },
+  "-MYTw6FkVguRJGamHu29" : {
+    "event_firebaseKey" : "-MYSBHf-jV_yTvMZTVz8",
+    "firebaseKey" : "-MYTw6FkVguRJGamHu29",
+    "staff_firebaseKey" : "-CS8TBPUiwbjKRhvG5Uz"
+  },
+  "-MYTwBDwFYreuXcPgPoO" : {
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBDwFYreuXcPgPoO",
+    "staff_firebaseKey" : "-CSCPwAIAg2hTA1XULGc"
+  },
+  "-MYTwBE12mX-Hs8u5C-u" : {
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBE12mX-Hs8u5C-u",
+    "staff_firebaseKey" : "-CSNFup34oXLq9bbdXnk"
+  },
+  "-MYTwBEJrWDqtaf2kJyc" : {
+    "event_firebaseKey" : "-MYT-BafTnkwBY-UdfWH",
+    "firebaseKey" : "-MYTwBEJrWDqtaf2kJyc",
+    "staff_firebaseKey" : "-CSRCLIYxRDnnOOC2G2Q"
+  },
+  "-MYTwVp5pu3sykCL9laX" : {
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVp5pu3sykCL9laX",
+    "staff_firebaseKey" : "-CS8TBPUiwbjKRhvG5Uz"
+  },
+  "-MYTwVpORucSJP_v66-s" : {
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVpORucSJP_v66-s",
+    "staff_firebaseKey" : "-CSCPwAIAg2hTA1XULGc"
+  },
+  "-MYTwVpadcQ9Y9BAhB49" : {
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVpadcQ9Y9BAhB49",
+    "staff_firebaseKey" : "-CSNFup34oXLq9bbdXnk"
+  },
+  "-MYTwVpihD3WvT_G3q2B" : {
+    "event_firebaseKey" : "-MYS0v3qmXBLjlAcpr5j",
+    "firebaseKey" : "-MYTwVpihD3WvT_G3q2B",
+    "staff_firebaseKey" : "-CSNFup34oXLq9fbcXnk"
+  },
+  "-MYVBXthipdWwjtJ7rYf" : {
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXthipdWwjtJ7rYf",
+    "staff_firebaseKey" : "-CS8TBPUiwbjKRhvG5Uz"
+  },
+  "-MYVBXtiio0-q3tvNmPT" : {
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXtiio0-q3tvNmPT",
+    "staff_firebaseKey" : "-CSCPwAIAg2hTA1XULGc"
+  },
+  "-MYVBXtzZGpc2cXbX3gc" : {
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXtzZGpc2cXbX3gc",
+    "staff_firebaseKey" : "-CSNFup34oXLq9bbdXnk"
+  },
+  "-MYVBXuFSntxgY4PD1pT" : {
+    "event_firebaseKey" : "-MYV5rpei5Cm_F7oGOA9",
+    "firebaseKey" : "-MYVBXuFSntxgY4PD1pT",
+    "staff_firebaseKey" : "-CSdP5J71Trra6tpmuDl"
+  },
+  "-MYVJuxb9-ZxLYF31-kb" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuxb9-ZxLYF31-kb",
+    "staff_firebaseKey" : "-CSCPwAIAg2hTA1XULGc"
+  },
+  "-MYVJuxqskE3_fDb0zq3" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuxqskE3_fDb0zq3",
+    "staff_firebaseKey" : "-CSQxSoGKznGShFypOJz"
+  },
+  "-MYVJuyL2lkjJj8xd5t4" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuyL2lkjJj8xd5t4",
+    "staff_firebaseKey" : "-MYHdWhKUDHttCn27Grs"
+  },
+  "-MYVJuySpBQsGo8njYZW" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuySpBQsGo8njYZW",
+    "staff_firebaseKey" : "-MYHdz3jNz3bUHimldxA"
+  },
+  "-MYVJuz7mwD5NwtFEIjO" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJuz7mwD5NwtFEIjO",
+    "staff_firebaseKey" : "-CSNFup34oXLq9bbdXnk"
+  },
+  "-MYVJv5KxnT6izVeJt8b" : {
+    "event_firebaseKey" : "-MYS-pQ-q9ZsTNN77IA6",
+    "firebaseKey" : "-MYVJv5KxnT6izVeJt8b",
+    "staff_firebaseKey" : "-CSRCLIYxRDnnOOC2G2Q"
+  },
+  "-MYbUXoS-TkeezYcXxRT" : {
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXoS-TkeezYcXxRT",
+    "staff_firebaseKey" : "-CSNFup34oXLq9bbdXnk"
+  },
+  "-MYbUXpefrZXi77aI1nF" : {
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXpefrZXi77aI1nF",
+    "staff_firebaseKey" : "-CSNFup34oXLq9fbcXnk"
+  },
+  "-MYbUXpefrZXi77aI1nH" : {
+    "event_firebaseKey" : "-MYRx6B4HwgVcikFoybX",
+    "firebaseKey" : "-MYbUXpefrZXi77aI1nH",
+    "staff_firebaseKey" : "-CSCPwAIAg2hTA1XULGc"
+  }
+}

--- a/json_sample_data/food.json
+++ b/json_sample_data/food.json
@@ -1,102 +1,102 @@
 {
-  "-MVqxNqxoNTgbacrgc_W": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNqxoNTgbacrgc_W",
-    "name": "Lambas Bread",
-    "image": "https://4.bp.blogspot.com/_cd6_MFUGTUE/SU6yFC_7eHI/AAAAAAAAAII/dgbwkYf3cZs/s320/_DSC6981.jpg",
-    "description": "A savory elvish bread with magical properties. Don't eat too much!",
-    "price": 15,
-    "vegetarian": true,
-    "glutenFree": true
+  "-MVqxNqxoNTgbacrgc_W" : {
+    "description" : "A savory elvish bread with magical properties. Don't eat too much!",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNqxoNTgbacrgc_W",
+    "glutenFree" : false,
+    "image" : "https://4.bp.blogspot.com/_cd6_MFUGTUE/SU6yFC_7eHI/AAAAAAAAAII/dgbwkYf3cZs/s320/_DSC6981.jpg",
+    "name" : "Lambas Bread",
+    "price" : "20",
+    "vegetarian" : true
   },
-  "-MVqxNqzjWxKXeC6lbs2": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNqzjWxKXeC6lbs2",
-    "name": "Po-tay-toes",
-    "image": "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/delish-191907-twice-baked-potatoes-0027-landscape-pf-1564166855.png",
-    "description": "You can boil em' mash em' or put em' in a stew. We just filled them with cheesy goodness.",
-    "price": 9,
-    "vegetarian": true,
-    "glutenFree": true
+  "-MVqxNqzjWxKXeC6lbs2" : {
+    "description" : "You can boil em' mash em' or put em' in a stew. We just filled them with cheesy goodness.",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNqzjWxKXeC6lbs2",
+    "glutenFree" : true,
+    "image" : "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/delish-191907-twice-baked-potatoes-0027-landscape-pf-1564166855.png",
+    "name" : "Po-tay-toes",
+    "price" : 9,
+    "vegetarian" : true
   },
-  "-MVqxNr0wVophcLKgolo": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNr0wVophcLKgolo",
-    "name": "Bofur's Mince Pies",
-    "image": "https://i0.wp.com/www.feastofstarlight.com/wp-content/uploads/2015/12/the-hobbit-bofurs-mince-pies-title.jpg?w=2000",
-    "description": "A light and delicious mince pie that would entice any dwarf to share an ale with you.",
-    "price": 5,
-    "vegetarian": false,
-    "glutenFree": false
+  "-MVqxNr0wVophcLKgolo" : {
+    "description" : "A light and delicious mince pie that would entice any dwarf to share an ale with you.",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNr0wVophcLKgolo",
+    "glutenFree" : false,
+    "image" : "https://i0.wp.com/www.feastofstarlight.com/wp-content/uploads/2015/12/the-hobbit-bofurs-mince-pies-title.jpg?w=2000",
+    "name" : "Bofur's Mince Pies",
+    "price" : 5,
+    "vegetarian" : false
   },
-  "-MVqxNr2P3K2XSNYcnhH": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNr2P3K2XSNYcnhH",
-    "name": "Bilbo's Seed Cakes",
-    "image": "https://i.pinimg.com/750x/46/96/d3/4696d337a7bb885e04fdcb8d860cb0a2.jpg",
-    "description": "A tasty pound cake filled with caraway seeds!",
-    "price": 6,
-    "vegetarian": false,
-    "glutenFree": false
+  "-MVqxNr2P3K2XSNYcnhH" : {
+    "description" : "A tasty pound cake filled with caraway seeds!",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNr2P3K2XSNYcnhH",
+    "glutenFree" : false,
+    "image" : "https://i.pinimg.com/750x/46/96/d3/4696d337a7bb885e04fdcb8d860cb0a2.jpg",
+    "name" : "Bilbo's Seed Cakes",
+    "price" : 6,
+    "vegetarian" : false
   },
-  "-MVqxNr4OrvYigAth_eb": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNr4OrvYigAth_eb",
-    "name": "Lamb Stew",
-    "image": "https://i1.wp.com/www.feastofstarlight.com/wp-content/uploads/2015/07/recipes-from-bag-end-weta-lamb-stew-close-up.jpg",
-    "description": "A classic lamb stew with flavours of Hobbiton.",
-    "price": 18,
-    "vegetarian": false,
-    "glutenFree": false
+  "-MVqxNr4OrvYigAth_eb" : {
+    "description" : "A classic lamb stew with flavours of Hobbiton.",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNr4OrvYigAth_eb",
+    "glutenFree" : false,
+    "image" : "https://i1.wp.com/www.feastofstarlight.com/wp-content/uploads/2015/07/recipes-from-bag-end-weta-lamb-stew-close-up.jpg",
+    "name" : "Lamb Stew",
+    "price" : 18,
+    "vegetarian" : false
   },
-  "-MVqxNr74tqCjRkC_V9H": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNr74tqCjRkC_V9H",
-    "name": "Fish and Chips",
-    "image": "https://www.thespruceeats.com/thmb/t_rcaInDM6kmQ66F8EfNQ7xJwq0=/960x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/best-fish-and-chips-recipe-434856-Hero-5b61b89346e0fb00500f2141.jpg",
-    "description": "Some fried goodies for the little ones.",
-    "price": 8,
-    "vegetarian": false,
-    "glutenFree": false
+  "-MVqxNr74tqCjRkC_V9H" : {
+    "description" : "Some fried goodies for the little ones.",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNr74tqCjRkC_V9H",
+    "glutenFree" : false,
+    "image" : "https://www.thespruceeats.com/thmb/t_rcaInDM6kmQ66F8EfNQ7xJwq0=/960x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/best-fish-and-chips-recipe-434856-Hero-5b61b89346e0fb00500f2141.jpg",
+    "name" : "Fish and Chips",
+    "price" : 8,
+    "vegetarian" : false
   },
-  "-MVqxNr9L_9VM_ScMj6R": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNr9L_9VM_ScMj6R",
-    "name": "Gollum's Dinner",
-    "image": "https://cdn-japantimes.com/wp-content/uploads/2018/07/n-edomae-a-20180719.jpg",
-    "description": "Raw fish for the Gollum in you... Raw and wriggling!",
-    "price": 20,
-    "vegetarian": false,
-    "glutenFree": false
+  "-MVqxNr9L_9VM_ScMj6R" : {
+    "description" : "Raw fish for the Gollum in you... Raw and wriggling!",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNr9L_9VM_ScMj6R",
+    "glutenFree" : false,
+    "image" : "https://cdn-japantimes.com/wp-content/uploads/2018/07/n-edomae-a-20180719.jpg",
+    "name" : "Gollum's Dinner",
+    "price" : 20,
+    "vegetarian" : false
   },
-  "-MVqxNrB0w4QXvgBr_Zj": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNrB0w4QXvgBr_Zj",
-    "name": "Balin's Spiced Beef",
-    "image": "https://midearthfoodie.files.wordpress.com/2013/02/balins-spiced-beef-castiron1.jpg",
-    "description": "Balin's favorite spiced beef. The key to any legendary feast.",
-    "price": 25,
-    "vegetarian": false,
-    "glutenFree": true
+  "-MVqxNrB0w4QXvgBr_Zj" : {
+    "description" : "Balin's favorite spiced beef. The key to any legendary feast.",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNrB0w4QXvgBr_Zj",
+    "glutenFree" : true,
+    "image" : "https://midearthfoodie.files.wordpress.com/2013/02/balins-spiced-beef-castiron1.jpg",
+    "name" : "Balin's Spiced Beef",
+    "price" : 25,
+    "vegetarian" : false
   },
-  "-MVqxNrEduzMS9XvYbbA": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNrEduzMS9XvYbbA",
-    "name": "LOTR Cupcakes",
-    "image": "https://i.pinimg.com/originals/96/ae/19/96ae19ca7f4ba5916d913d5285b4763a.jpg",
-    "description": "Classic cupcakes with a middle-earth theme.",
-    "price": 8,
-    "vegetarian": true,
-    "glutenFree": false
+  "-MVqxNrEduzMS9XvYbbA" : {
+    "description" : "Classic cupcakes with a middle-earth theme.",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNrEduzMS9XvYbbA",
+    "glutenFree" : false,
+    "image" : "https://i.pinimg.com/originals/96/ae/19/96ae19ca7f4ba5916d913d5285b4763a.jpg",
+    "name" : "LOTR Cupcakes",
+    "price" : 8,
+    "vegetarian" : true
   },
-  "-MVqxNrHhO8NRulKEu00": {
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey": "-MVqxNrHhO8NRulKEu00",
-    "name": "Eye of Sauron Eggs",
-    "image": "https://live.staticflickr.com/4104/5082620741_85c5d288bb_b.jpg",
-    "description": "Deviled eggs from Mordor. Eat at your own risk.",
-    "price": 2,
-    "vegetarian": false,
-    "glutenFree": true
+  "-MVqxNrHhO8NRulKEu00" : {
+    "description" : "Deviled eggs from Mordor. Eat at your own risk.",
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-MVqxNrHhO8NRulKEu00",
+    "glutenFree" : true,
+    "image" : "https://live.staticflickr.com/4104/5082620741_85c5d288bb_b.jpg",
+    "name" : "Eye of Sauron Eggs",
+    "price" : 2,
+    "vegetarian" : false
   }
 }

--- a/json_sample_data/shows.json
+++ b/json_sample_data/shows.json
@@ -1,19 +1,12 @@
 {
-  "-MW1hHPko8IhAcdheGbC" : {
-    "date" : "2021-03-22",
-    "description" : "Comedy for the ages",
-    "event_id" : "-MUuao2lynNljpuXaHnJ",
-    "firebaseKey" : "-MW1hHPko8IhAcdheGbC",
-    "image" : "https://i.pinimg.com/600x315/b6/aa/e5/b6aae5af7b13aec67d02dfef6c2bc10b.jpg",
-    "name" : "Merry and Pippin's Excellent Adventure"
-  },
   "-MW6U7ptyGymUBEkVJ_X" : {
     "date" : "2021-03-31",
     "description" : "the greatest love story ever told!",
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MW6U7ptyGymUBEkVJ_X",
     "image" : "https://images-na.ssl-images-amazon.com/images/I/81kqjTQKqWL.jpg",
-    "name" : "Beren and Luthien"
+    "name" : "Beren and Luthien",
+    "show_price" : "300"
   },
   "-MW6VnIg6ke6Qs6rLA9y" : {
     "date" : "2021-04-06",
@@ -21,7 +14,8 @@
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MW6VnIg6ke6Qs6rLA9y",
     "image" : "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTu46MbdRShAsjG3Y00uiczo24lGzTub1e-BumLINCXHdB4tVw6dvOhH57UrA&usqp=CAc",
-    "name" : "The Children of Hurin"
+    "name" : "The Children of Hurin",
+    "show_price" : 300
   },
   "-MW6WAfWIj6GUI9lQthz" : {
     "date" : "2021-04-03",
@@ -29,7 +23,8 @@
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MW6WAfWIj6GUI9lQthz",
     "image" : "http://www.fictorians.com/wp-content/uploads/2016/04/Samwise-2.jpg",
-    "name" : "Po-Tae-Toes"
+    "name" : "Po-Tay-Toes",
+    "show_price" : "350"
   },
   "-MW6Ws0hRa-NZE1Qbnh7" : {
     "date" : "2021-03-14",
@@ -37,7 +32,8 @@
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MW6Ws0hRa-NZE1Qbnh7",
     "image" : "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/lord-of-the-rings-sean-bean-boromir-1584636601.jpg",
-    "name" : "One Does Not Simply Walk Into Mordor"
+    "name" : "One Does Not Simply Walk Into Mordor",
+    "show_price" : 350
   },
   "-MW6XK8xmtlEycbP3OwQ" : {
     "date" : "2021-03-23",
@@ -45,7 +41,8 @@
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MW6XK8xmtlEycbP3OwQ",
     "image" : "https://images.indianexpress.com/2020/06/ian-holm-759.jpg",
-    "name" : "Bilbo's Birthday Bash"
+    "name" : "Bilbo's Birthday Bash",
+    "show_price" : 400
   },
   "-MW6XfQed8lwUl-fFws1" : {
     "date" : "2021-03-28",
@@ -53,7 +50,8 @@
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MW6XfQed8lwUl-fFws1",
     "image" : "https://upload.wikimedia.org/wikipedia/en/thumb/a/aa/%C3%89owyn_with_sword.jpg/170px-%C3%89owyn_with_sword.jpg",
-    "name" : "I Am No Man"
+    "name" : "I Am No Man",
+    "show_price" : 200
   },
   "-MW6Y96LBUFZEhnr5UrA" : {
     "date" : "2021-04-03",
@@ -61,7 +59,8 @@
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MW6Y96LBUFZEhnr5UrA",
     "image" : "https://fictionhorizon.com/wp-content/uploads/2020/03/Aragorn.jpg",
-    "name" : "The Rangers"
+    "name" : "The Rangers",
+    "show_price" : 150
   },
   "-MW6Yew43S2eiLaGrUmr" : {
     "date" : "2021-03-21",
@@ -69,7 +68,8 @@
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MW6Yew43S2eiLaGrUmr",
     "image" : "https://static3.srcdn.com/wordpress/wp-content/uploads/2019/12/Orlando-Bloom-as-Legolas-and-John-Rhys-Davies-as-Gimli-in-The-Lord-Of-The-Rings.jpg",
-    "name" : "Showdown: Legolas and Gimli"
+    "name" : "Showdown: Legolas and Gimli",
+    "show_price" : 150
   },
   "-MW6YwQKsQ4hnNYDoEOC" : {
     "date" : "2021-03-28",
@@ -77,6 +77,16 @@
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MW6YwQKsQ4hnNYDoEOC",
     "image" : "https://thinkchristian-webassets.imgix.net/articleImages/2012/gollum.jpg?crop=focalpoint&fit=crop&fp-x=0.5&fp-y=0.5&h=500&ixlib=php-1.1.0&q=80&w=800&s=e4f4a4f4978b8cd6cd064ff3f26cc713",
-    "name" : "Dr. Gollum and Mr. Smeagol"
+    "name" : "Dr. Gollum and Mr. Smeagol",
+    "show_price" : 200
+  },
+  "-MYCYcmEfs017WI1INjX" : {
+    "date" : "2021-08-24",
+    "description" : "The best costume wins!",
+    "event_id" : "-MY2qZPoNMdrb-ktod74",
+    "firebaseKey" : "-MYCYcmEfs017WI1INjX",
+    "image" : "https://c8.alamy.com/comp/W3CN8P/renaissance-festival-actors-in-16th-century-costumes-larkspur-colorado-july-13-2019-W3CN8P.jpg",
+    "name" : "Costume Contest",
+    "show_price" : "160"
   }
 }

--- a/json_sample_data/souvenirs.json
+++ b/json_sample_data/souvenirs.json
@@ -5,7 +5,7 @@
     "name" : "Glamdring",
     "souvenir_description" : "Glamdring (also called the Foe-hammer and the Beater) was a hand-and-a-half sword, forged for Turgon, the Elven King of Gondolin during the First Age, and much later owned by the wizard Gandalf.",
     "souvenir_image" : "https://i.pinimg.com/originals/59/f5/bc/59f5bc18f11c97fb9dce10319cf3ff2b.jpg",
-    "souvenir_price" : "200 Castar"
+    "souvenir_price" : 200
   },
   "-MVndERf6PlFfusGKN2i" : {
     "event_id" : "-MUuao2lynNljpuXaHnJ",
@@ -13,7 +13,7 @@
     "name" : "Flag of the Rohirrim",
     "souvenir_description" : "In The Lord of the Rings, Rohan is important in the action, first against the wizard Saruman in the Battle of the Hornburg, and then in the climactic Battle of the Pelennor Fields. There, Théoden leads the Rohirrim to victory against the forces of Mordor; he is killed when his horse falls, but his niece Éowyn kills the leader of the Ringwraiths.",
     "souvenir_image" : "https://i.pinimg.com/originals/7e/8d/e1/7e8de126a2e16b3116a55b4fd7ff59e1.jpg",
-    "souvenir_price" : "100 Castar"
+    "souvenir_price" : 100
   },
   "-MVnfLMclD-h0_3C2qy3" : {
     "event_id" : "-MUuao2lynNljpuXaHnJ",
@@ -21,7 +21,7 @@
     "name" : "Long Tobacco Smoking Pipe",
     "souvenir_description" : "Hobbits invented the art of smoking pipeweed. They are fond of an unadventurous, bucolic, and simple life of farming, eating, and socializing, although capable of defending their homes courageously if the need arises. They would enjoy six meals a day, if they could get them. This pipe nods to the culture of Hobbiton and to Bilbo's adventures in the Misty Mountains.",
     "souvenir_image" : "https://images-na.ssl-images-amazon.com/images/I/81KV65TuppL._SL1500_.jpg",
-    "souvenir_price" : "55 Castar"
+    "souvenir_price" : 55
   },
   "-MVnhhGTf8Ygx01P4iWQ" : {
     "event_id" : "-MUuao2lynNljpuXaHnJ",
@@ -29,23 +29,23 @@
     "name" : "Leaves of Lorien",
     "souvenir_description" : "The Leaves of Lorien were brooches given by Galadriel to the members of the Fellowship of the Ring (except for Gandalf, presumed at the time to be dead) at the end of their stay at Lothlórien. They looked like the new-opened leaves of a beech-tree.",
     "souvenir_image" : "https://i.pinimg.com/originals/43/a1/46/43a146f1f150414522a51df99d824eec.jpg",
-    "souvenir_price" : "40 Castar"
+    "souvenir_price" : 40
   },
   "-MVniWGtwTOMp6n4FW75" : {
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MVniWGtwTOMp6n4FW75",
     "name" : "Elessar Pendant",
     "souvenir_description" : "The Elessar or Elfstone was a gem set on a silver eagle-shaped brooch. It had the light of the Sun within it and those who looked through it saw everything that was aged and withered as young once more.",
-    "souvenir_image" : "https://static.wikia.nocookie.net/lotr/images/2/24/Elessar-the-elfstone-silver-324411_720x.jpg/revision/latest/scale-to-width-down/350?cb=20200826032323",
-    "souvenir_price" : "99 Castar"
+    "souvenir_image" : "https://ae01.alicdn.com/kf/H3d8f0359acd646d2853ea0a806678133O/Arwen-Evenstar-Necklace-Elfstone-Elessar-Aragorn-Galadriel-Elves-Princess-Cubic-Zirconia-Stone-Pendant-Jewelry-Women-Wholesale.jpg_q50.jpg",
+    "souvenir_price" : 99
   },
   "-MVnjlKvzRVVKsoz0dWg" : {
     "event_id" : "-MUuao2lynNljpuXaHnJ",
     "firebaseKey" : "-MVnjlKvzRVVKsoz0dWg",
     "name" : "The Hat of Tom Bombadil",
     "souvenir_description" : "But I had forgotten Bombadil, if indeed this is still the same that walked the woods and hills long ago, and even then was older than the old. That was not then his name. Iarwain Ben-adar we called him, oldest and fatherless. But many another name he has since been given by other folk: Forn by the Dwarves, Orald by Northern Men, and other names beside. He is a strange creature...",
-    "souvenir_image" : "https://static.wikia.nocookie.net/lotr/images/9/9c/Tom_Bombadil%27s_hat.png/revision/latest/scale-to-width-down/340?cb=20101211165007",
-    "souvenir_price" : "29 Castar"
+    "souvenir_image" : "https://www.thetolkienforum.com/wiki-asset/?pid=50&dpr=2.625",
+    "souvenir_price" : 29
   },
   "-MVnkrRDIBgBMyA1m6Ax" : {
     "event_id" : "-MUuao2lynNljpuXaHnJ",
@@ -53,7 +53,7 @@
     "name" : "Palantir",
     "souvenir_description" : "The Palantíri (singular palantír), also known as Seeing-stones, the Seven Stones, or the Seven Seeing-stones, were spherical stone objects used for the purpose of communication in Middle-earth. There were eight distinguished ones in total.",
     "souvenir_image" : "https://i.pinimg.com/564x/ea/e0/e7/eae0e7d77bc876fb6e72e1838b1fe64d.jpg",
-    "souvenir_price" : "75 Castar"
+    "souvenir_price" : 75
   },
   "-MVnllXyYum9Wt2EcgE3" : {
     "event_id" : "-MUuao2lynNljpuXaHnJ",
@@ -61,7 +61,7 @@
     "name" : "Athelas",
     "souvenir_description" : "Athelas, also known as Kingsfoil or Asëa Aranion, was a healing herb that grew throughout Middle-earth.",
     "souvenir_image" : "https://images.adagio.com/images2/custom_blends/148718.jpg",
-    "souvenir_price" : "6 Castar per quessë"
+    "souvenir_price" : 6
   },
   "-MVnn6PwrmHC_3a5UQFS" : {
     "event_id" : "-MUuao2lynNljpuXaHnJ",
@@ -69,7 +69,7 @@
     "name" : "The Prancing Pony | Pub Sign",
     "souvenir_description" : "The Prancing Pony (i.e. the Inn of the Prancing Pony) was an inn in Bree where Frodo Baggins, Sam, Pippin, and Merry first met Strider.",
     "souvenir_image" : "https://i.pinimg.com/736x/e9/f9/77/e9f9776967a02e318344b4f6629b4ad3.jpg",
-    "souvenir_price" : "15 Castar"
+    "souvenir_price" : 15
   },
   "-MVnp0LjWmmJdI2Uj-kd" : {
     "event_id" : "-MUuao2lynNljpuXaHnJ",
@@ -77,6 +77,13 @@
     "name" : "The Red Book of the Westmarch",
     "souvenir_description" : "The Red Book of Westmarch was a red-leather bound book written by the Hobbit Bilbo Baggins and his household-heir Frodo Baggins, (with supplemental information later added by Samwise Gamgee) which chronicled both their adventures, as well as background information which the Bagginses had collected.Bilbo Baggins started the book recounting his quest to Erebor, which he entitled There and Back Again. He later gave the book to Frodo at Rivendell after completing it. Frodo organized Bilbo's manuscript and used it to write down his own quest of the War of the Ring.",
     "souvenir_image" : "https://i.etsystatic.com/11850003/r/il/f58c2c/2285832332/il_570xN.2285832332_7lhj.jpg",
-    "souvenir_price" : "500 Castar"
+    "souvenir_price" : 50
+  },
+  "-MYHdrRUxvMEuU9PY0LX" : {
+    "firebaseKey" : "-MYHdrRUxvMEuU9PY0LX",
+    "name" : "Lindsey's ol' pandemic hair wig",
+    "souvenir_description" : "Lindsey cut her pandemic hair off and now you can own it",
+    "souvenir_image" : "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAoHCBYVFRgVFhYYGBgaHBocGRgaGBgYGBgZGhwaHBoYGBgcIS4lHB4rIxgYJjgmKy8xNTU1GiQ7QDszPy40NTEBDAwMEA8QHxISHjQrJCs2NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NP/AABEIARMAtwMBIgACEQEDEQH/xAAbAAACAwEBAQAAAAAAAAAAAAAEBQIDBgABB//EAD4QAAEDAgMFBgQDBgYDAQAAAAEAAhEDIQQSMQVBUWFxBiKBkaGxMsHR8BNCUiNicoKy4TOSosLS8RRz4gf/xAAZAQADAQEBAAAAAAAAAAAAAAABAgMABAX/xAAkEQACAwEAAwEAAgMBAQAAAAAAAQIRITEDEkEyIlETYaFCBP/aAAwDAQACEQMRAD8Ac4GldMWtuhqCOaFOI7IOYrWhcGqxoRMeMF1Oo1eMIlSraLGOohXtCpw6JCBgOpqgMQ2zke8XQddsh3Fc8iiIYQIsmyz+J7QUMO7K9/eiYaMxA5xoh6nbGm9v7Nr3E8RYHndVi6WiODb4ahZntI7vgbgBKoZ2gqxMT1DcvSBdLcTthtV4NRuR2Ug72nhBWl5FJUjf4ZR0abLNwtRh5hZXZYEghanCaKkXhKSBdvOApE8Ep2WcyZdpGE0SBrb3S7YjbLL9BaqI9oNS7tFjCxhaNXD0Tei3RZftJWBqEAjui/Xgh5OGh0p2BP4z3HdE+QWpqXusz2Ydme88z/ZaQ2sj4+Gn1mR25TzYho4NK9VmL72JPJq5GwGgoiYR+WyDwzUc0JFwrLpFhA3qYevBTUqbEQEmtvKnVFlAsv1VjljHmHCvabTyQ9OoLqWJJ/CcRYwUreBStnz7b3bSo17qdJrWwYDz3iTyGk+azOM2liHsOes8neMxE+AsU02XhWOec9iSZNoJv+pe7WwlMEFvmN4+fgoeyujs/wAVKzJNFz6ollNzbiRwKLwuDnN1dHG0AHn/AHTGkMwgjePSx+qeUzRgJ6eOeBJJsjKeND7PHQ+xUK+GyEtPwu/0u1HRBUabiSwAkzAAEkybAAamVqi9QLaxmg2XtT8J4Buzhy5c/vgvpOzyHNDgQQRII0IO9fLqXZ/EucwFhZMkOdJEgTl7gJB6hbDsJWqNzYeqxwyjOx0HKWk/DPqAbwTayeNrDn8sYvUMe1NUsp21JA80v2M7uhS7aV4cxvG/kULsepdMn/Joi/yh3tLaH4dMlvxRA6rDtrl7nZjrJcVpNsPP4JjUmJjSNVkGuu7xCScrYYqkaDshUlxjRa/FtgSsX2WqhrgFsce/uE8lWH5El0yuGvXe7XcuVuwWy5zuJK5YOGjwyMahsMEULJVwpLpIBWMCgFY0JgHm+4XrhKi8XXtJ1kDEcNRuZU9pCKNQjcx0dYsPNRw/xTO9FUqArU6gDjD8zb/lLZabdRPikl+cKQ/Vs+LY/Dd97Q4wHRIOscDwRGyMCLseJa4XIEEEaGYt1RWP2Q+m/I8QeoAN9QTqE0w2Aa1uYv73Ij5Fcrk0qPQ9U9FGwdmPfWfSzAFmVwLrAtL2gvndEi3gp7Yw/wCE99MkZwGkgGYzNaS08xoeYKIwG3Bhqjy5sh4u4NzEZc0QCQD8R1MLSnAUi9uIFOnmqVMrD3nvDmksY93eGb4cxblAAvqJVEvbSEpODr4Zp3Z+u8Me+mGsIBcKjxTzBoL3SYLmd0OvEjXcrdr7Sw2GY40DTdXeSGmnkhgkEF+S0t/KT3jOsSk/aHaeIqsaKjHsHdJcXOLXuawtllg1oOZ7iLk5r8Ej/ADAf4iFVJRJtuTth21NvYioGjM5kQXEPd3iAxt+A7gdHEkqrCdp8S1+dz8/dLQDDYGstyxBtrrc8V1dwcxx5fRLS2zRyn1RUrQsopGw2ztA1ntd+4zXiQEw2OJssvsx/cHKB4G/zK0myq2W/kli6k7IyjlB/aDE5WtZOgJnmbeax7rJ7jj+J3zblv8AFLKtEfIJZO2BLAzs5UioAfBbLbFSKJKw+ymkPbHJa3tE+KIVoPAMG2A2Gkrl5s0fsmjxK5PYlD+kYRrRZB0WI6ICnHhWRzRIVzQq6WiuYE6ARc1UtcJIRLkPkEkoMyLGACEy2dh8jSd7nFxsBr06BBYaHOAI+wmhcpyY6Rg//wBCLczCB39LQT1grP4bGy27mkDUOBaR/Lceq0nausxoe8iXQQOVv7+qyTWAUX1BZxDR0aBIHOwE8yVyN+zbPQgqikL8fhM7iWEcbaDxsmlKvXpYdzC8b2gtY0vaIhzQ92g1bYSLwQlL8U58NkNI+EiMubecu+LQjMPgQGZfxXnWZINzrGu9UTa+iySl1F2G7RUqtJ2Gq08jHkiRlhkwGlgAsQ45sxmwOu8XanZOpTpAtzveLujKWPl5YMmjgcpY64Iu6/dSXH4drXTc9LSiMNteu1hZ+K/KAMrASdCIE6gCFdMhKNcKH4RzaWYgiTDmkEFre7BM8THmErqv73Ld0WtxW1BVBygNAa0uk53iLEhxG6SbToBqLLMdsVndy1GMMXkkh5AAkXtJk8II8dB9sWTeE9mM7gPGPRaDAsuORSfDNy5W2sxtheCS6xPGMp8U6wJDYJ1SpaSk9GjsO0stpr4pDjKXejxn5rR1KcsDp7tp3HqgKuFL7tFo8+CZxBFi3ZlnzCddpav7No4lB7PwpLxxBupbePeY3xRi6Qsunj6xZRABgmJPKdFyoxlqempEdFyVt2E2mCHsEagcOQCEcnjw0ukmhWtVTdyuaE4CAuq61grgh3mTCEjII2ee/HIptkSnAiHg+HmnMqdFL/o+adrMMXGdxFS+tzVc3/h5ILamGYGZGHuyXOcYOkC3lCdY7E/i4htJvwsqGeZDi4+GiRdqagl7G2AIBj9Ikn5Bcf8Ao9GOIzTKBe8xplJ6A2H18kAaxZ3XSCN4OvMrQbEADnWmYHWBKF27gBEiJsPEWgq0JK/Vk5r+NiBoDnOubAm/KJ+aYYVppBryySbh2f5JVReWuzaHQ9N6tzudLWvIAJ7uYx1G5WlG8IRkloTjceHvLouenvql1epcFdXYeNxrqi8Js99QS1jnDTujeOJ3IxiooEpNui/Y1d5OWDlJ8j1W32RQBPeBiLn6c0r2Vs0spw9sFzpEQYFhHotXszBOiQJ0ETA6oJWyM2TrNLQcwGQ6C8ngIQmy2HM8njpyNwm9agMpbcAcD81HD4bKwb+KdrSalgDgaffcY4+6VbUOasANxC07GQFmXDNXJ5pvVIX2LsVs3OyZj/tcm2NZ+zi+7Rcl9UG2X0tB4JjSFkBhm2b0CZAJYFJHmiIaqHq9miohTwoIHvdUdU0QTBaTxSsKDKViPBE4vGBu9C05KhiMKx93Nk8ZI9kklg8Gk9MnsRhZVc9+6nUeCd5zT6Z0rxNIOZ+I/R4L+oB7o8XR6rR7ewuVncJEgtP81vmkm3x3GNbdrcrD0hoP+qfNclbR6EXatfRHsQF7Hvb8THhwHhf+n0U9q1cxPBwPm0SD5Fe7MBpF7TZrw0g+Zn3Hig6z+8Rwn+lwTf8Aq0bsaZmsRZzh194V+Aw5eTB70SJ38vkqqzhn8T6kx9UTgxlfl04FdTdI5Yq2V1md3SI+IcE47O7S/wDHOV8mm+M0bj+scxvG8dEpxFXvzudr10J8V6/4Mp3XHW/0Q3DOKdn1h2EbVa1zCCLEEaEWMpthaGWQdFhewG2Mo/BebT3CdROren1X0Bz1SFM5JpxZQ5lyrRTEKLSrAmYgLi7NPQrMYNk1U/2tUIYQlGzKcuzc1umWDp5gL1TLbLlqDZ5SbAHJFMqIWi6R1VzGlSiWkXuV7VS7crQnEPHcEOGd09US8LxiDRkdQcpusFENIJUq7bBLLgV0R7dksIGpDvRpPyWVxWKnK8AlhEFv6i8SfLMfGVs8a0Zmg/pqH0Df93qso/CxTDBrZo5TOY/fFck3Uj0PD+aF2KZkpZJksHdO8tm088vsks9wuPIdTH0lPdpU4c1g1yX3gAZQPvmUsdQlkaNptPi46k+XkOaMWUoy2JYQ+Z19DoUwo088Ebre4+ihi6QAadxg+bUw2dh4ZmiBlLr89PZXlLEznhGpP+hOGF7wzmb8ANT6KeJMvA0FoHBo0le4R4Lzwv5H+0+aor1M73O/UYA5fYTfRLVX/Zu+x2DY9zYMkOzujg0C3mQPNfQKo0hfJuyu2ThyTAcDAcOU6g+K+m4LaDKzQ9hEG+uiMGlhDzJvQpoViqa6SrJVCNYJttvgFD7MZAHNS227dxKswjYy9EwPgxcbLl6uWNSBNk1S9jDyHomlPRIezzppDkSnzLKMOHR5FUmcTEK1zrSq3NkLtycmdnmytbqhQJk6Imm6UEZljSc0Kdb4VW111e+kXNP3MFCXAx1mUZiDVxB3MDajA473tDXEdAPUHgluMdDwAYMWjjYT7pzXoZcNTLdWAVDG8OaRUnwc4+CRvd+1YToGgnzJ+q4ZdPT8apf8ANq1QHPG9oDfKPmktV5LMn6nXjhAnzuPFXtr/iMe/eTB/wAyowT4ZnMGC4jrNoTRVBk8KNoUIDWbwcpO6fzeAuP5VdjKuXDkNPxdwcmNkeZiUvxNazGnW5ceJMyfMlRq1cxDN0tHoQPkrKPCDlrF7GkFw+96rptJuEzq04ObxPI6OHt5FUVWZCCLg3+oVUyTjpLDGCXcpj3HqrWvcxxykgi7SDB8CvS5ogjT66+68qWGY77D5+yndjeuGq2H2hxRBjJWDYJa45HhpIFjoQCRJP6gVrtlbbZXzMyup1GfHTf8Q5jiOfTivlFKs9jpYTmggc2uEFpnrC0lLGlj8PXe17HDuvc8uLXscDJzZdN+9OpUSn47Rp9qmXhF0mfClb8SHuztIImxBBBFtCE0aTI8FW105aaDiLLl40yFyYIBsOnkos4m/mnQ0SDYBJpiToSB0BT5gsow4X8n6ODu6rqVNzjDQSfvUoakCbASSYA5k2WloUQxoaPGNSU6JMRDA1M2XLE7zcAcSQrcXhPwWZpLzma1rR3Zc9waJN4EkX4J2x140tpw6qvG0czCBrYj+JpDm+oC3rhk90Cw2GygZu87eYgTyG4K+FWyqHAOGhgr0vUy9CdjYLmH8hiP3HSR6QPBYbaNE06r2ahrTlJ6Ej09ytttU5KrHjR4LHddW/NJO0DgajRFyyeoDoIPhHkVyyVHZ43/ANMhsOmCXNO8yB0cCfQHyQTmBrHs0AfAHLvG3IyCicPULKjmixB7vXcD/EDCHxnfzR+afA3b7Oailoz4K9psiOYB9G/IhC0ZeS3iQR4Hd5I3HvDqeYbva4j0QmAfDgfH2XRHInNLZF7MRDwX6TDvGxPz8F1WnGZp/KT7KjEDM+pGk+whGMYfwn1HcAAeJ0+vkg8Qy/kwHDtm3P5I9rM2Zvl119pQGEPeadw+59ExqPyuB/e/pJ/5LSAuEGM3bxp8vYLX4F7nuwzA6Q0VHgEWAaGgCRu7/osvUhrxwM+RWj7PCWZ2kZ6eYAE2cx2rTw0aZ5BLHos8RdUYGPDg3LLgHAaODnAT1BIutM1qzj3B+RkEOzgkHUBsu8RIFwtJlt5K0Uto5Z3SsI3LlXUfYLlSxKFewavcLQPhcZ8brRM0SLYFOGOP6nlPQbKUS03oZsikM5cd2nU2+qc1XxpcnRJdiVJeW8p8j/dOQJcTwVFwm+lbe6JNySJPEkx5BEOKFxN3sbzzHw0VlN+Zs/fNYwsrDI8t/K+XM6/nb5mf5uSrL0fjsPnYWzB1a7g4aH5HkSklOqTYiCCQ4bwRqFKSpl4O0e7VZnpO4t7w6tv9Uij8ao+3wUss83ST8lpWiRHFZjD1W0mPfPx5o8C4R6Fc0+2dXjeUYHaL++5w/KbxuBv7lSdUDnP4FubxkNf7z4r2pJbUfaJaAYvJE/RCMxOR7HG4ILXDiCC0+hnwTRVoeTrQR12PB/e8LgqnDUyG+Et58R6IzF0socBcEx4EofCv7hG8GQfvqqp5hL10qwPez8SD5zKO2zWAayk3QCTzOgnnqfFBshr3kCAW5hyzNmPC4Q1R5Li4/doCavZ2In6qgjC2a7kAPOCiqNcHLPP1/ulrKkA88v0XtJ2nis43YFLg+YwPcAdJPkRZONi4EOD3CxAEQYOhnK7cRbkb9RmMNVcNNRMLT9msa0tezR5v0ABlTS002/V0MMLmc9s/G09C4HiOcQVpMwMRySTAAOe4m8NGvGT9+Ka0RGluU71WOHNLQmqLLl7UErlShLFmyHEtMmzXEBP2GyT7KpwzqSU2p6KcesrLQnZFqw8fZaCmZJWbwRiqwj9QHnZaSjvVETZTPfc7c0fJU7PdALTqAD/nGb3lEMZZ075QVJ8VnD9TR6BZhQW4pVtjCEft2CSB32j8zR+YD9Q9R4JqdVw4ISjaNGTi7E1CoCAQZBiOawe3XuY7KdIygbhJ7x/0+q3OKw/4Uub8BmR+h3/E+h6hYra+WrTLZhzYk9bz0+S4vLkkj0fA7TaM3Xqh7A1vwh2u99R2p/hAP3KWYqh32gaNifb6nxV9Ko7MWixaCObTvPVTcQ2JEiZPEwZMn71TxxjSVotxtEDI3fILuh3eQ9Uoe0NMbyZI4C/19EzpYwMa6o+73fCP0zMu5mDAGgSU4iMz95NuXDy+ieEXwlNpKyWKf3iBuaB5CD6yq8NTzg8QDZUNf6oqnmpuY8b9eY3j1VGqVIndu/hSwAi3l0uuw3srKtOHmN5+ypUWEX4/L7CzeGUdLsI/K+InXyTXEYf8L8DENJ7/AMUHUHX76Jeyj3mv/fYB0MiUy2rLGMpbi7M3lOoHK4PWeCQ0u0bTB0g1ttNZ4/VMcMyRJQOGByMEXyt9gmLLABVRyMsqFcouK5UFBdnVe6AmgNkr2UAG34lMs25RXWWYVs7/ABGdfYErRUtCs5sr/FZ/N/S5aNhtCoibPGCGmd6TbSq5KtM8ZBTvcVme0zoLTwj+oISxDRVsfuO8LwPQtOqAGifyj2H1CuLkbAV4mJIPwuEEdfsrAY3AkVHiIzNgcA4EgT971v3gELNdoO49lSJaTlI5nd47ua5fPG6Z1f8AzT9W0fO2Mh+YiDv+XtHgl20apY8xBiY133HofVNNrPy1XNFxOZhG9jriPRJcf3zO/Q8oSQW6dUnawEaXOJcby2fGdyHyd0lGv7rABrfwBVOGZII4fOx+S6E/pBxvGAU9VoBRH4Qe7Rs+J4eZPkkgZ3o5wnWIf3WN3anrM/TzW8j5QnjVJ2DOZOQ8ZHlJVz2Z35G7pv01PyV9Bmg4O+o+arcz8N8+nI8FOxzqNUSxrhEPBfAmzA6SAm7GHFYlrmtIpMnKXCMwBEkf6Qo4N7WYmi8aOaQTuk2B62haYiaxP6Wgf5j/APPqqRVkJyoYBwMeyJagmHUotirRCybiuVVU8FywCvZo7repTIpXs1/damZKmvpaQVsw/tW/zf0lPcOVncE+KrPEebSneHfdOmIw15t5LMdrBZgG8geoWkcdfD5pD2m0aeB+YQnwMOgeOxeSsxpMNcGgfxhvzA9AnFKrLQsL2qxEweL2geAcT7LUbGrlzGzrASJ6NKOJjQvCUbdph9F7CdR3eOb8sJjUMCUn2q5xbuzRDR+8UPJKojeJXJHzzajHPpNqEXZOkXGYT5OMDxCH2jh4e02LnAQRa8XlaTG4KWNYPgESf1ZTbwmT1ngszjsQWuM6CYvFzYBRjbR12rFFdp+EcTP396q/BU7OJEajwifqjsLRJMuA/Lpe1yb+HqrsUwWbpN3Hg0ffomcsoH2zOGkS8WjMbdCdeiY1GZ9N0kD1jyhD1n3Lh0b03/fNGYIlrmPdZpMHx0Tyd0IssvbH4ebideBH3KKova8AuAjfPFB1zkfUYT3RcDdy9SmXZvDtcRn0F5P6QPsJaA3SA6mHLJyBxZcscQRwLsoN4BAIO+CtTsd4e0v1LiD07rbeBlemkHva2D3buncS0gN/1ExujmqNmH8P8SmbFpkDk7hy18wqRxkJP2Q2Y7VFsOiCokaIkPlVsjRNxXKtxXiYBVgHAMCaNck2BeMgTOi6bqC6y8lhex0PYeBBTvPDvFZys5PWvzBruIBRsWhmx1j4fNJe0wmmmtN1j4JZty7EZfkWP6MD2lMMpO4PBPTK4FbLYZ7glZHtGyaJHCPotL2drh1JhzAy1pvYiySPSs+DvEDTr8iR6ws6+oXkv3S5rPPKXepCf1SUjdRhuQatPzkJfIrD43QJixNMdfSBHskGK2ax85hznSOa0b2ywt0IA1G8W+aWGm4/ER0Gn90KzB090z1CmGb4Ze35oFhbzVONokj955AHIbh6K80c4ewfESWSbBrWmJHEwNOaYV8LJZbSfEiHDzykJKrSrlbozOMwobVYw2Gk/PzTOpgg+k6NZOXllsPUK/a+AD2ZmC4OYG+inhamag60ODYPQ2n38QnsXWKsNg3VnF7tLStls/AhtMOIiSI4hoB9/ogdiMDWOEWzFPcS+QOZB8I/6TxV6Q8smnRThqQBMCBOg90sxtP9sHD9MHzEexTdzsrD0S6mJcD9lO1eEVJrQnDNjrvKLbxQzFMPsmjgr0mVygXr1OawPZ7pEc02pOASXZEkuTVyhxl+osLgZCb7Of3AN7THgbj5pESr6GILSI/7WsDRqWO+LogNqXYimHU8Qg8S6WpnwVdMVto/sX8hPqE87M0g2kxrgYAgEXjqEox0Q9p0hw+S0GyaJY0R9+CnErLgyJaNHA/fBB1mgnnxTAhrviEHioPwE6OHiPonoknQrcyx6R6/2StzFpKmzngaN/6t80G3Zrvlu1WGsztTZrHEuu0nWIg8y0yJ5qwYWBEndB3g7itCNnbzohMSxrXMOokE9AYPlPslcUMpMW4fZ5dJ0F54HjlSuphhTzgju3g+WZvsfBb2pSGS35b24b48JWdxmADy9hJm+UDScstPPuyB/AklFvg8PJT0UbMpkME6ul3STp7Jo0y3ogxaxtJPg8ajx180Vh3buPyVYKkS8jttkcfUhoaNXKikzvdFLHO77eSnhmb+aeiRwcQotcVZXGpVLdUTfD0uM3XKMTdcsAo2RVjMOaZtcSUh2We+U6YTmUX0uuFhmVLNBXrze6g25WCaXB4gPZIO644HggfxZJCowb8jXundEc+KGfV/aNaN0SeZ3LSlQsYivarO+/hrHWDHqtzRwkQs1Tw4fimNIkEzH8Dc3u0LaMeDbQhGCNN8PGUeS9bRaDIC9e+FUyoTdUJkXkucQOLW9IEn3CDwtTMA4aGs4Do3M32ARRP4dN7zqA53jFvkhdlU4p0AdZLj1gn5pWgrhzHWb/OP8rg72BSXHt7n8Dyw9DYf7E4A77BxfUHm0pViWE/+QzfAeOrR/wDIS0MmNdm1MzBPQpRtSkWFrhq05D/VTd/tROxa0jqJ8fv2Rm0sOHiN1RuQng4XYfNHqBxma2lREh4s2oPJ39ihKTyDfUG/UJjhxnY5jviEwODhYj3S19r+DvkVgkcW/M8cBoiGut090G74kW4Q1P8ACbK31rQqmOUclySrmCyCutMzwPC5QdTXLabBJ2dc9z3lx3LT0dQsx2Tacr3GbkALTU3XUVf0vL/QVUG9VNfdTdVlVBM2BFzSCrQ9rZtPjEHjzVNMCV7WIW+ACdi1AcSxxGs+EtIW1c0FYfYrf2zP5v6XLYsqwcrvA8U0OCz6eV2TZTYwAL1yg8pxRb2hqzTyD8zgPCZKLosg0xwHyQG0hmqsbwkprHeb0Q+m+CvEOipS/wDY72KHxjcuJHBwIKs2gYq0v4/kV52gbD2P4EIBE+yH5JafyOLT4Ej2WieMzHN3iHDqFmqndxFQbnZXj+YX9QVocDVnIeIg9dD6hBBYh2h3KweLCoM38ws4IXH0wHZh8Lgmu3KHcdGrHZh0OvzS8d9mXxaiZCl4g33WRFQ2Vb2zHHRTeFrFktKHO3BSe8rynv6qFRyRydlFFUSNVcgK2IgrkfZi+pDYdqbeqd01y5KO+l7dFwXLljIsZqueuXLfDfQzZP8Ai0/4wtVivhB4QuXJ48El09pmQFMrlyoKKsT/AI46Jn+YLlyCAxPtP/EZ/H9Vb2h+AeC5cl/sZfDOY/8Ax2c6Y9Cm+z/gHJ//ABXLkAvgTtIfF/CVmsN8LPFcuTMC4CYj4j1XBcuQMykaOQNV54rlykhxfiNVy5cmMf/Z",
+    "souvenir_price" : "54"
   }
 }

--- a/json_sample_data/staff.json
+++ b/json_sample_data/staff.json
@@ -1,92 +1,118 @@
 {
-  "-CSYAqbLM6ZZRtBvyxAt": {
-    "firebaseKey": "-CSYAqbLM6ZZRtBvyxAt",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Frodo",
-    "last_name": "Baggins",
-    "staff_image": "https://images.unsplash.com/photo-1596574202467-915fa42375c8?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=867&q=80",
-    "years_worked": 5,
-    "role": "Destroyer of the ring, hero"
+  "-CS8TBPUiwbjKRhvG5Uz" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CS8TBPUiwbjKRhvG5Uz",
+    "first_name" : "Gimli",
+    "last_name" : "",
+    "role" : "Well respected dwarf warrior",
+    "staff_image" : "https://www.publicdomainpictures.net/pictures/10000/velka/1081-1241021821oGjG.jpg",
+    "staff_price" : 150,
+    "years_worked" : 9
   },
-  "-CSQxSoGKznGShFypOJz": {
-    "firebaseKey": "-CSQxSoGKznGShFypOJz",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Thorin",
-    "last_name": "",
-    "staff_image": "https://images.unsplash.com/photo-1511267462094-52a45dd66809?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&auto=format&fit=crop&w=1850&q=80",
-    "years_worked": 15,
-    "role": "Leader of the clan, a descendant of king dwarves of old and the most important"
+  "-CSCPwAIAg2hTA1XULGc" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CSCPwAIAg2hTA1XULGc",
+    "first_name" : "Arwen",
+    "last_name" : "",
+    "role" : "Queen overflowing with knowledge and thought",
+    "staff_image" : "https://images.unsplash.com/photo-1523260578934-e9318da58c8d?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTA2fHxjb3NwbGF5fGVufDB8fDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=900&q=60",
+    "staff_price" : 175,
+    "years_worked" : 4
   },
-  "-CSXBfLa27HeEHN3iIEp": {
-    "firebaseKey": "-CSXBfLa27HeEHN3iIEp",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Gollum",
-    "last_name": "",
-    "staff_image": "https://images.unsplash.com/photo-1517423738875-5ce310acd3da?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTA5fHxjb3NwbGF5fGVufDB8fDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=900&q=60",
-    "years_worked": 1,
-    "role": "Representer of greed, ambition, cleverness and goodness (and the cutest of us all)"
+  "-CSNFup34oXLq9bbdXnk" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CSNFup34oXLq9bbdXnk",
+    "first_name" : "Rosie",
+    "last_name" : "Cotton",
+    "role" : "strong mother of thirteen children",
+    "staff_image" : "https://images.unsplash.com/photo-1571652542118-5cc33c994b7c?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTI2fHxjb3NwbGF5fGVufDB8fDB8&auto=format&fit=crop&w=900&q=60",
+    "staff_price" : 250,
+    "years_worked" : 2
   },
-  "-CSdP5J71Trra6tpmuDl": {
-    "firebaseKey": "-CSdP5J71Trra6tpmuDl",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Galadriel",
-    "last_name": "",
-    "staff_image": "https://images.unsplash.com/photo-1614578595532-a9e522ffb0fb?ixid=MXwxMjA3fDB8MHxzZWFyY2h8NjZ8fGNvc3BsYXl8ZW58MHx8MHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=900&q=60",
-    "years_worked": 8,
-    "role": "Most powerful elf in the entire realm of Middle Earth"
+  "-CSNFup34oXLq9fbcXnk" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CSNFup34oXLq9fbcXnk",
+    "first_name" : "Treebeard",
+    "last_name" : "",
+    "role" : "Gentle Giant. Nobody has seen them nor talked to them until today, but you might be the lucky one.",
+    "staff_image" : "https://cnet1.cbsistatic.com/img/7AeDa-EPcic28Uj1KF-I8Jnnjgs=/940x0/2017/05/07/35276ddf-5d7a-448c-9c7c-d675e3c61aa7/grootpushingbutton.jpg",
+    "staff_price" : 225,
+    "years_worked" : 120
   },
-  "-CSCPwAIAg2hTA1XULGc": {
-    "firebaseKey": "-CSCPwAIAg2hTA1XULGc",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Arwen",
-    "last_name": "",
-    "staff_image": "https://images.unsplash.com/photo-1523260578934-e9318da58c8d?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTA2fHxjb3NwbGF5fGVufDB8fDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=900&q=60",
-    "years_worked": 4,
-    "role": "Queen overflowing with knowledge and thought"
+  "-CSNFup34oXLq9fbdXnk" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CSNFup34oXLq9fbdXnk",
+    "first_name" : "Eowyn",
+    "last_name" : "OfRohan",
+    "role" : "Noblewoman who bears the weight of destiny",
+    "staff_image" : "https://images.unsplash.com/photo-1561569912-9f202ecac634?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxzZWFyY2h8NTF8fGNvc3BsYXl8ZW58MHx8MHw%3D&auto=format&fit=crop&w=900&q=60",
+    "staff_price" : 145,
+    "years_worked" : 1
   },
-  "-CSRCLIYxRDnnOOC2G2Q": {
-    "firebaseKey": "-CSRCLIYxRDnnOOC2G2Q",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Aragorn",
-    "last_name": "",
-    "staff_image": "https://images.unsplash.com/photo-1615105113716-63952cd0cba8?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=975&q=80",
-    "years_worked": 7,
-    "role": "The rightful king of Gondor and the heir of Isildur"
+  "-CSQxSoGKznGShFypOJz" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CSQxSoGKznGShFypOJz",
+    "first_name" : "Thorin",
+    "last_name" : "",
+    "role" : "Leader of the clan, a descendant of king dwarves of old and the most important",
+    "staff_image" : "https://images.unsplash.com/photo-1511267462094-52a45dd66809?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&auto=format&fit=crop&w=1850&q=80",
+    "staff_price" : 275,
+    "years_worked" : 15
   },
-  "-CSNFup34oXLq9fbcXnk": {
-    "firebaseKey": "-CSNFup34oXLq9fbcXnk",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Treebeard",
-    "last_name": "",
-    "staff_image": "https://cnet1.cbsistatic.com/img/7AeDa-EPcic28Uj1KF-I8Jnnjgs=/940x0/2017/05/07/35276ddf-5d7a-448c-9c7c-d675e3c61aa7/grootpushingbutton.jpg",
-    "years_worked": 120,
-    "role": "Gentle Giant. Nobody has seen them nor talked to them until today, but you might be the lucky one."
+  "-CSRCLIYxRDnnOOC2G2Q" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CSRCLIYxRDnnOOC2G2Q",
+    "first_name" : "Aragorn",
+    "last_name" : "",
+    "role" : "The rightful king of Gondor and the heir of Isildur",
+    "staff_image" : "https://images.unsplash.com/photo-1615105113716-63952cd0cba8?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=975&q=80",
+    "staff_price" : 250,
+    "years_worked" : 7
   },
-  "-CS8TBPUiwbjKRhvG5Uz": {
-    "firebaseKey": "-CS8TBPUiwbjKRhvG5Uz",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Gimli",
-    "last_name": "",
-    "staff_image": "https://www.publicdomainpictures.net/pictures/10000/velka/1081-1241021821oGjG.jpg",
-    "years_worked": 9,
-    "role": "Well respected dwarf warrior"
+  "-CSXBfLa27HeEHN3iIEp" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CSXBfLa27HeEHN3iIEp",
+    "first_name" : "Gollum",
+    "last_name" : "",
+    "role" : "Representer of greed, ambition, cleverness and goodness (and the cutest of us all)",
+    "staff_image" : "https://images.unsplash.com/photo-1517423738875-5ce310acd3da?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTA5fHxjb3NwbGF5fGVufDB8fDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=900&q=60",
+    "staff_price" : 225,
+    "years_worked" : 1
   },
-  "-CSNFup34oXLq9fbdXnk": {
-    "firebaseKey": "-CSNFup34oXLq9fbdXnk",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Eowyn",
-    "last_name": "OfRohan",
-    "staff_image": "https://images.unsplash.com/photo-1561569912-9f202ecac634?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxzZWFyY2h8NTF8fGNvc3BsYXl8ZW58MHx8MHw%3D&auto=format&fit=crop&w=900&q=60",
-    "years_worked": 1,
-    "role": "Noblewoman who bears the weight of destiny"
+  "-CSYAqbLM6ZZRtBvyxAt" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CSYAqbLM6ZZRtBvyxAt",
+    "first_name" : "Frodo",
+    "last_name" : "Baggins",
+    "role" : "Destroyer of the ring, hero",
+    "staff_image" : "https://images.unsplash.com/photo-1596574202467-915fa42375c8?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=867&q=80",
+    "staff_price" : 145,
+    "years_worked" : 5
   },
-  "-CSNFup34oXLq9bbdXnk": {
-    "firebaseKey": "-CSNFup34oXLq9bbdXnk",
-    "event_id": "-MUuao2lynNljpuXaHnJ",
-    "first_name": "Rosie",
-    "last_name": "Cotton",
-    "staff_image": "https://images.unsplash.com/photo-1571652542118-5cc33c994b7c?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTI2fHxjb3NwbGF5fGVufDB8fDB8&auto=format&fit=crop&w=900&q=60",
-    "years_worked": 2,
-    "role": "strong mother of thirteen children"
+  "-CSdP5J71Trra6tpmuDl" : {
+    "event_id" : "-MUuao2lynNljpuXaHnJ",
+    "firebaseKey" : "-CSdP5J71Trra6tpmuDl",
+    "first_name" : "Galadriel",
+    "last_name" : "",
+    "role" : "Most powerful elf in the entire realm of Middle Earth",
+    "staff_image" : "https://images.unsplash.com/photo-1614578595532-a9e522ffb0fb?ixid=MXwxMjA3fDB8MHxzZWFyY2h8NjZ8fGNvc3BsYXl8ZW58MHx8MHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=900&q=60",
+    "staff_price" : "325",
+    "years_worked" : 8
+  },
+  "-MYHdWhKUDHttCn27Grs" : {
+    "firebaseKey" : "-MYHdWhKUDHttCn27Grs",
+    "first_name" : "Super",
+    "last_name" : "Man",
+    "role" : "Hero",
+    "staff_image" : "https://i.imgur.com/HQQUCoV.jpg",
+    "staff_price" : "350"
+  },
+  "-MYHdz3jNz3bUHimldxA" : {
+    "firebaseKey" : "-MYHdz3jNz3bUHimldxA",
+    "first_name" : "Ye ol' Lindsey",
+    "last_name" : "S",
+    "role" : "Turkey leg eater",
+    "staff_image" : "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAoHCBYVFRgVFhYYGBgaHBocGRgaGBgYGBgZGhwaHBoYGBgcIS4lHB4rIxgYJjgmKy8xNTU1GiQ7QDszPy40NTEBDAwMEA8QHxISHjQrJCs2NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NP/AABEIARMAtwMBIgACEQEDEQH/xAAbAAACAwEBAQAAAAAAAAAAAAAEBQIDBgABB//EAD4QAAEDAgMFBgQDBgYDAQAAAAEAAhEDIQQSMQVBUWFxBiKBkaGxMsHR8BNCUiNicoKy4TOSosLS8RRz4gf/xAAZAQADAQEBAAAAAAAAAAAAAAABAgMABAX/xAAkEQACAwEAAwEAAgMBAQAAAAAAAQIRITEDEkEyIlETYaFCBP/aAAwDAQACEQMRAD8Ac4GldMWtuhqCOaFOI7IOYrWhcGqxoRMeMF1Oo1eMIlSraLGOohXtCpw6JCBgOpqgMQ2zke8XQddsh3Fc8iiIYQIsmyz+J7QUMO7K9/eiYaMxA5xoh6nbGm9v7Nr3E8RYHndVi6WiODb4ahZntI7vgbgBKoZ2gqxMT1DcvSBdLcTthtV4NRuR2Ug72nhBWl5FJUjf4ZR0abLNwtRh5hZXZYEghanCaKkXhKSBdvOApE8Ep2WcyZdpGE0SBrb3S7YjbLL9BaqI9oNS7tFjCxhaNXD0Tei3RZftJWBqEAjui/Xgh5OGh0p2BP4z3HdE+QWpqXusz2Ydme88z/ZaQ2sj4+Gn1mR25TzYho4NK9VmL72JPJq5GwGgoiYR+WyDwzUc0JFwrLpFhA3qYevBTUqbEQEmtvKnVFlAsv1VjljHmHCvabTyQ9OoLqWJJ/CcRYwUreBStnz7b3bSo17qdJrWwYDz3iTyGk+azOM2liHsOes8neMxE+AsU02XhWOec9iSZNoJv+pe7WwlMEFvmN4+fgoeyujs/wAVKzJNFz6ollNzbiRwKLwuDnN1dHG0AHn/AHTGkMwgjePSx+qeUzRgJ6eOeBJJsjKeND7PHQ+xUK+GyEtPwu/0u1HRBUabiSwAkzAAEkybAAamVqi9QLaxmg2XtT8J4Buzhy5c/vgvpOzyHNDgQQRII0IO9fLqXZ/EucwFhZMkOdJEgTl7gJB6hbDsJWqNzYeqxwyjOx0HKWk/DPqAbwTayeNrDn8sYvUMe1NUsp21JA80v2M7uhS7aV4cxvG/kULsepdMn/Joi/yh3tLaH4dMlvxRA6rDtrl7nZjrJcVpNsPP4JjUmJjSNVkGuu7xCScrYYqkaDshUlxjRa/FtgSsX2WqhrgFsce/uE8lWH5El0yuGvXe7XcuVuwWy5zuJK5YOGjwyMahsMEULJVwpLpIBWMCgFY0JgHm+4XrhKi8XXtJ1kDEcNRuZU9pCKNQjcx0dYsPNRw/xTO9FUqArU6gDjD8zb/lLZabdRPikl+cKQ/Vs+LY/Dd97Q4wHRIOscDwRGyMCLseJa4XIEEEaGYt1RWP2Q+m/I8QeoAN9QTqE0w2Aa1uYv73Ij5Fcrk0qPQ9U9FGwdmPfWfSzAFmVwLrAtL2gvndEi3gp7Yw/wCE99MkZwGkgGYzNaS08xoeYKIwG3Bhqjy5sh4u4NzEZc0QCQD8R1MLSnAUi9uIFOnmqVMrD3nvDmksY93eGb4cxblAAvqJVEvbSEpODr4Zp3Z+u8Me+mGsIBcKjxTzBoL3SYLmd0OvEjXcrdr7Sw2GY40DTdXeSGmnkhgkEF+S0t/KT3jOsSk/aHaeIqsaKjHsHdJcXOLXuawtllg1oOZ7iLk5r8Ej/ADAf4iFVJRJtuTth21NvYioGjM5kQXEPd3iAxt+A7gdHEkqrCdp8S1+dz8/dLQDDYGstyxBtrrc8V1dwcxx5fRLS2zRyn1RUrQsopGw2ztA1ntd+4zXiQEw2OJssvsx/cHKB4G/zK0myq2W/kli6k7IyjlB/aDE5WtZOgJnmbeax7rJ7jj+J3zblv8AFLKtEfIJZO2BLAzs5UioAfBbLbFSKJKw+ymkPbHJa3tE+KIVoPAMG2A2Gkrl5s0fsmjxK5PYlD+kYRrRZB0WI6ICnHhWRzRIVzQq6WiuYE6ARc1UtcJIRLkPkEkoMyLGACEy2dh8jSd7nFxsBr06BBYaHOAI+wmhcpyY6Rg//wBCLczCB39LQT1grP4bGy27mkDUOBaR/Lceq0nausxoe8iXQQOVv7+qyTWAUX1BZxDR0aBIHOwE8yVyN+zbPQgqikL8fhM7iWEcbaDxsmlKvXpYdzC8b2gtY0vaIhzQ92g1bYSLwQlL8U58NkNI+EiMubecu+LQjMPgQGZfxXnWZINzrGu9UTa+iySl1F2G7RUqtJ2Gq08jHkiRlhkwGlgAsQ45sxmwOu8XanZOpTpAtzveLujKWPl5YMmjgcpY64Iu6/dSXH4drXTc9LSiMNteu1hZ+K/KAMrASdCIE6gCFdMhKNcKH4RzaWYgiTDmkEFre7BM8THmErqv73Ld0WtxW1BVBygNAa0uk53iLEhxG6SbToBqLLMdsVndy1GMMXkkh5AAkXtJk8II8dB9sWTeE9mM7gPGPRaDAsuORSfDNy5W2sxtheCS6xPGMp8U6wJDYJ1SpaSk9GjsO0stpr4pDjKXejxn5rR1KcsDp7tp3HqgKuFL7tFo8+CZxBFi3ZlnzCddpav7No4lB7PwpLxxBupbePeY3xRi6Qsunj6xZRABgmJPKdFyoxlqempEdFyVt2E2mCHsEagcOQCEcnjw0ukmhWtVTdyuaE4CAuq61grgh3mTCEjII2ee/HIptkSnAiHg+HmnMqdFL/o+adrMMXGdxFS+tzVc3/h5ILamGYGZGHuyXOcYOkC3lCdY7E/i4htJvwsqGeZDi4+GiRdqagl7G2AIBj9Ikn5Bcf8Ao9GOIzTKBe8xplJ6A2H18kAaxZ3XSCN4OvMrQbEADnWmYHWBKF27gBEiJsPEWgq0JK/Vk5r+NiBoDnOubAm/KJ+aYYVppBryySbh2f5JVReWuzaHQ9N6tzudLWvIAJ7uYx1G5WlG8IRkloTjceHvLouenvql1epcFdXYeNxrqi8Js99QS1jnDTujeOJ3IxiooEpNui/Y1d5OWDlJ8j1W32RQBPeBiLn6c0r2Vs0spw9sFzpEQYFhHotXszBOiQJ0ETA6oJWyM2TrNLQcwGQ6C8ngIQmy2HM8njpyNwm9agMpbcAcD81HD4bKwb+KdrSalgDgaffcY4+6VbUOasANxC07GQFmXDNXJ5pvVIX2LsVs3OyZj/tcm2NZ+zi+7Rcl9UG2X0tB4JjSFkBhm2b0CZAJYFJHmiIaqHq9miohTwoIHvdUdU0QTBaTxSsKDKViPBE4vGBu9C05KhiMKx93Nk8ZI9kklg8Gk9MnsRhZVc9+6nUeCd5zT6Z0rxNIOZ+I/R4L+oB7o8XR6rR7ewuVncJEgtP81vmkm3x3GNbdrcrD0hoP+qfNclbR6EXatfRHsQF7Hvb8THhwHhf+n0U9q1cxPBwPm0SD5Fe7MBpF7TZrw0g+Zn3Hig6z+8Rwn+lwTf8Aq0bsaZmsRZzh194V+Aw5eTB70SJ38vkqqzhn8T6kx9UTgxlfl04FdTdI5Yq2V1md3SI+IcE47O7S/wDHOV8mm+M0bj+scxvG8dEpxFXvzudr10J8V6/4Mp3XHW/0Q3DOKdn1h2EbVa1zCCLEEaEWMpthaGWQdFhewG2Mo/BebT3CdROren1X0Bz1SFM5JpxZQ5lyrRTEKLSrAmYgLi7NPQrMYNk1U/2tUIYQlGzKcuzc1umWDp5gL1TLbLlqDZ5SbAHJFMqIWi6R1VzGlSiWkXuV7VS7crQnEPHcEOGd09US8LxiDRkdQcpusFENIJUq7bBLLgV0R7dksIGpDvRpPyWVxWKnK8AlhEFv6i8SfLMfGVs8a0Zmg/pqH0Df93qso/CxTDBrZo5TOY/fFck3Uj0PD+aF2KZkpZJksHdO8tm088vsks9wuPIdTH0lPdpU4c1g1yX3gAZQPvmUsdQlkaNptPi46k+XkOaMWUoy2JYQ+Z19DoUwo088Ebre4+ihi6QAadxg+bUw2dh4ZmiBlLr89PZXlLEznhGpP+hOGF7wzmb8ANT6KeJMvA0FoHBo0le4R4Lzwv5H+0+aor1M73O/UYA5fYTfRLVX/Zu+x2DY9zYMkOzujg0C3mQPNfQKo0hfJuyu2ThyTAcDAcOU6g+K+m4LaDKzQ9hEG+uiMGlhDzJvQpoViqa6SrJVCNYJttvgFD7MZAHNS227dxKswjYy9EwPgxcbLl6uWNSBNk1S9jDyHomlPRIezzppDkSnzLKMOHR5FUmcTEK1zrSq3NkLtycmdnmytbqhQJk6Imm6UEZljSc0Kdb4VW111e+kXNP3MFCXAx1mUZiDVxB3MDajA473tDXEdAPUHgluMdDwAYMWjjYT7pzXoZcNTLdWAVDG8OaRUnwc4+CRvd+1YToGgnzJ+q4ZdPT8apf8ANq1QHPG9oDfKPmktV5LMn6nXjhAnzuPFXtr/iMe/eTB/wAyowT4ZnMGC4jrNoTRVBk8KNoUIDWbwcpO6fzeAuP5VdjKuXDkNPxdwcmNkeZiUvxNazGnW5ceJMyfMlRq1cxDN0tHoQPkrKPCDlrF7GkFw+96rptJuEzq04ObxPI6OHt5FUVWZCCLg3+oVUyTjpLDGCXcpj3HqrWvcxxykgi7SDB8CvS5ogjT66+68qWGY77D5+yndjeuGq2H2hxRBjJWDYJa45HhpIFjoQCRJP6gVrtlbbZXzMyup1GfHTf8Q5jiOfTivlFKs9jpYTmggc2uEFpnrC0lLGlj8PXe17HDuvc8uLXscDJzZdN+9OpUSn47Rp9qmXhF0mfClb8SHuztIImxBBBFtCE0aTI8FW105aaDiLLl40yFyYIBsOnkos4m/mnQ0SDYBJpiToSB0BT5gsow4X8n6ODu6rqVNzjDQSfvUoakCbASSYA5k2WloUQxoaPGNSU6JMRDA1M2XLE7zcAcSQrcXhPwWZpLzma1rR3Zc9waJN4EkX4J2x140tpw6qvG0czCBrYj+JpDm+oC3rhk90Cw2GygZu87eYgTyG4K+FWyqHAOGhgr0vUy9CdjYLmH8hiP3HSR6QPBYbaNE06r2ahrTlJ6Ej09ytttU5KrHjR4LHddW/NJO0DgajRFyyeoDoIPhHkVyyVHZ43/ANMhsOmCXNO8yB0cCfQHyQTmBrHs0AfAHLvG3IyCicPULKjmixB7vXcD/EDCHxnfzR+afA3b7Oailoz4K9psiOYB9G/IhC0ZeS3iQR4Hd5I3HvDqeYbva4j0QmAfDgfH2XRHInNLZF7MRDwX6TDvGxPz8F1WnGZp/KT7KjEDM+pGk+whGMYfwn1HcAAeJ0+vkg8Qy/kwHDtm3P5I9rM2Zvl119pQGEPeadw+59ExqPyuB/e/pJ/5LSAuEGM3bxp8vYLX4F7nuwzA6Q0VHgEWAaGgCRu7/osvUhrxwM+RWj7PCWZ2kZ6eYAE2cx2rTw0aZ5BLHos8RdUYGPDg3LLgHAaODnAT1BIutM1qzj3B+RkEOzgkHUBsu8RIFwtJlt5K0Uto5Z3SsI3LlXUfYLlSxKFewavcLQPhcZ8brRM0SLYFOGOP6nlPQbKUS03oZsikM5cd2nU2+qc1XxpcnRJdiVJeW8p8j/dOQJcTwVFwm+lbe6JNySJPEkx5BEOKFxN3sbzzHw0VlN+Zs/fNYwsrDI8t/K+XM6/nb5mf5uSrL0fjsPnYWzB1a7g4aH5HkSklOqTYiCCQ4bwRqFKSpl4O0e7VZnpO4t7w6tv9Uij8ao+3wUss83ST8lpWiRHFZjD1W0mPfPx5o8C4R6Fc0+2dXjeUYHaL++5w/KbxuBv7lSdUDnP4FubxkNf7z4r2pJbUfaJaAYvJE/RCMxOR7HG4ILXDiCC0+hnwTRVoeTrQR12PB/e8LgqnDUyG+Et58R6IzF0socBcEx4EofCv7hG8GQfvqqp5hL10qwPez8SD5zKO2zWAayk3QCTzOgnnqfFBshr3kCAW5hyzNmPC4Q1R5Li4/doCavZ2In6qgjC2a7kAPOCiqNcHLPP1/ulrKkA88v0XtJ2nis43YFLg+YwPcAdJPkRZONi4EOD3CxAEQYOhnK7cRbkb9RmMNVcNNRMLT9msa0tezR5v0ABlTS002/V0MMLmc9s/G09C4HiOcQVpMwMRySTAAOe4m8NGvGT9+Ka0RGluU71WOHNLQmqLLl7UErlShLFmyHEtMmzXEBP2GyT7KpwzqSU2p6KcesrLQnZFqw8fZaCmZJWbwRiqwj9QHnZaSjvVETZTPfc7c0fJU7PdALTqAD/nGb3lEMZZ075QVJ8VnD9TR6BZhQW4pVtjCEft2CSB32j8zR+YD9Q9R4JqdVw4ISjaNGTi7E1CoCAQZBiOawe3XuY7KdIygbhJ7x/0+q3OKw/4Uub8BmR+h3/E+h6hYra+WrTLZhzYk9bz0+S4vLkkj0fA7TaM3Xqh7A1vwh2u99R2p/hAP3KWYqh32gaNifb6nxV9Ko7MWixaCObTvPVTcQ2JEiZPEwZMn71TxxjSVotxtEDI3fILuh3eQ9Uoe0NMbyZI4C/19EzpYwMa6o+73fCP0zMu5mDAGgSU4iMz95NuXDy+ieEXwlNpKyWKf3iBuaB5CD6yq8NTzg8QDZUNf6oqnmpuY8b9eY3j1VGqVIndu/hSwAi3l0uuw3srKtOHmN5+ypUWEX4/L7CzeGUdLsI/K+InXyTXEYf8L8DENJ7/AMUHUHX76Jeyj3mv/fYB0MiUy2rLGMpbi7M3lOoHK4PWeCQ0u0bTB0g1ttNZ4/VMcMyRJQOGByMEXyt9gmLLABVRyMsqFcouK5UFBdnVe6AmgNkr2UAG34lMs25RXWWYVs7/ABGdfYErRUtCs5sr/FZ/N/S5aNhtCoibPGCGmd6TbSq5KtM8ZBTvcVme0zoLTwj+oISxDRVsfuO8LwPQtOqAGifyj2H1CuLkbAV4mJIPwuEEdfsrAY3AkVHiIzNgcA4EgT971v3gELNdoO49lSJaTlI5nd47ua5fPG6Z1f8AzT9W0fO2Mh+YiDv+XtHgl20apY8xBiY133HofVNNrPy1XNFxOZhG9jriPRJcf3zO/Q8oSQW6dUnawEaXOJcby2fGdyHyd0lGv7rABrfwBVOGZII4fOx+S6E/pBxvGAU9VoBRH4Qe7Rs+J4eZPkkgZ3o5wnWIf3WN3anrM/TzW8j5QnjVJ2DOZOQ8ZHlJVz2Z35G7pv01PyV9Bmg4O+o+arcz8N8+nI8FOxzqNUSxrhEPBfAmzA6SAm7GHFYlrmtIpMnKXCMwBEkf6Qo4N7WYmi8aOaQTuk2B62haYiaxP6Wgf5j/APPqqRVkJyoYBwMeyJagmHUotirRCybiuVVU8FywCvZo7repTIpXs1/damZKmvpaQVsw/tW/zf0lPcOVncE+KrPEebSneHfdOmIw15t5LMdrBZgG8geoWkcdfD5pD2m0aeB+YQnwMOgeOxeSsxpMNcGgfxhvzA9AnFKrLQsL2qxEweL2geAcT7LUbGrlzGzrASJ6NKOJjQvCUbdph9F7CdR3eOb8sJjUMCUn2q5xbuzRDR+8UPJKojeJXJHzzajHPpNqEXZOkXGYT5OMDxCH2jh4e02LnAQRa8XlaTG4KWNYPgESf1ZTbwmT1ngszjsQWuM6CYvFzYBRjbR12rFFdp+EcTP396q/BU7OJEajwifqjsLRJMuA/Lpe1yb+HqrsUwWbpN3Hg0ffomcsoH2zOGkS8WjMbdCdeiY1GZ9N0kD1jyhD1n3Lh0b03/fNGYIlrmPdZpMHx0Tyd0IssvbH4ebideBH3KKova8AuAjfPFB1zkfUYT3RcDdy9SmXZvDtcRn0F5P6QPsJaA3SA6mHLJyBxZcscQRwLsoN4BAIO+CtTsd4e0v1LiD07rbeBlemkHva2D3buncS0gN/1ExujmqNmH8P8SmbFpkDk7hy18wqRxkJP2Q2Y7VFsOiCokaIkPlVsjRNxXKtxXiYBVgHAMCaNck2BeMgTOi6bqC6y8lhex0PYeBBTvPDvFZys5PWvzBruIBRsWhmx1j4fNJe0wmmmtN1j4JZty7EZfkWP6MD2lMMpO4PBPTK4FbLYZ7glZHtGyaJHCPotL2drh1JhzAy1pvYiySPSs+DvEDTr8iR6ws6+oXkv3S5rPPKXepCf1SUjdRhuQatPzkJfIrD43QJixNMdfSBHskGK2ax85hznSOa0b2ywt0IA1G8W+aWGm4/ER0Gn90KzB090z1CmGb4Ze35oFhbzVONokj955AHIbh6K80c4ewfESWSbBrWmJHEwNOaYV8LJZbSfEiHDzykJKrSrlbozOMwobVYw2Gk/PzTOpgg+k6NZOXllsPUK/a+AD2ZmC4OYG+inhamag60ODYPQ2n38QnsXWKsNg3VnF7tLStls/AhtMOIiSI4hoB9/ogdiMDWOEWzFPcS+QOZB8I/6TxV6Q8smnRThqQBMCBOg90sxtP9sHD9MHzEexTdzsrD0S6mJcD9lO1eEVJrQnDNjrvKLbxQzFMPsmjgr0mVygXr1OawPZ7pEc02pOASXZEkuTVyhxl+osLgZCb7Of3AN7THgbj5pESr6GILSI/7WsDRqWO+LogNqXYimHU8Qg8S6WpnwVdMVto/sX8hPqE87M0g2kxrgYAgEXjqEox0Q9p0hw+S0GyaJY0R9+CnErLgyJaNHA/fBB1mgnnxTAhrviEHioPwE6OHiPonoknQrcyx6R6/2StzFpKmzngaN/6t80G3Zrvlu1WGsztTZrHEuu0nWIg8y0yJ5qwYWBEndB3g7itCNnbzohMSxrXMOokE9AYPlPslcUMpMW4fZ5dJ0F54HjlSuphhTzgju3g+WZvsfBb2pSGS35b24b48JWdxmADy9hJm+UDScstPPuyB/AklFvg8PJT0UbMpkME6ul3STp7Jo0y3ogxaxtJPg8ajx180Vh3buPyVYKkS8jttkcfUhoaNXKikzvdFLHO77eSnhmb+aeiRwcQotcVZXGpVLdUTfD0uM3XKMTdcsAo2RVjMOaZtcSUh2We+U6YTmUX0uuFhmVLNBXrze6g25WCaXB4gPZIO644HggfxZJCowb8jXundEc+KGfV/aNaN0SeZ3LSlQsYivarO+/hrHWDHqtzRwkQs1Tw4fimNIkEzH8Dc3u0LaMeDbQhGCNN8PGUeS9bRaDIC9e+FUyoTdUJkXkucQOLW9IEn3CDwtTMA4aGs4Do3M32ARRP4dN7zqA53jFvkhdlU4p0AdZLj1gn5pWgrhzHWb/OP8rg72BSXHt7n8Dyw9DYf7E4A77BxfUHm0pViWE/+QzfAeOrR/wDIS0MmNdm1MzBPQpRtSkWFrhq05D/VTd/tROxa0jqJ8fv2Rm0sOHiN1RuQng4XYfNHqBxma2lREh4s2oPJ39ihKTyDfUG/UJjhxnY5jviEwODhYj3S19r+DvkVgkcW/M8cBoiGut090G74kW4Q1P8ACbK31rQqmOUclySrmCyCutMzwPC5QdTXLabBJ2dc9z3lx3LT0dQsx2Tacr3GbkALTU3XUVf0vL/QVUG9VNfdTdVlVBM2BFzSCrQ9rZtPjEHjzVNMCV7WIW+ACdi1AcSxxGs+EtIW1c0FYfYrf2zP5v6XLYsqwcrvA8U0OCz6eV2TZTYwAL1yg8pxRb2hqzTyD8zgPCZKLosg0xwHyQG0hmqsbwkprHeb0Q+m+CvEOipS/wDY72KHxjcuJHBwIKs2gYq0v4/kV52gbD2P4EIBE+yH5JafyOLT4Ej2WieMzHN3iHDqFmqndxFQbnZXj+YX9QVocDVnIeIg9dD6hBBYh2h3KweLCoM38ws4IXH0wHZh8Lgmu3KHcdGrHZh0OvzS8d9mXxaiZCl4g33WRFQ2Vb2zHHRTeFrFktKHO3BSe8rynv6qFRyRydlFFUSNVcgK2IgrkfZi+pDYdqbeqd01y5KO+l7dFwXLljIsZqueuXLfDfQzZP8Ai0/4wtVivhB4QuXJ48El09pmQFMrlyoKKsT/AI46Jn+YLlyCAxPtP/EZ/H9Vb2h+AeC5cl/sZfDOY/8Ax2c6Y9Cm+z/gHJ//ABXLkAvgTtIfF/CVmsN8LPFcuTMC4CYj4j1XBcuQMykaOQNV54rlykhxfiNVy5cmMf/Z",
+    "staff_price" : "245"
   }
 }

--- a/src/javascripts/components/forms/editEventForm.js
+++ b/src/javascripts/components/forms/editEventForm.js
@@ -1,0 +1,39 @@
+// editEventForm.js
+import {
+  selectSouvenirs, selectShow, selectStaff, selectFood
+} from './selectItems';
+
+const editEventForm = (objEvent, objData) => {
+  document.querySelector('#add-button-container').innerHTML = '';
+  document.querySelector('#content-container').innerHTML = '';
+  document.querySelector('#content-container').innerHTML = `<form>
+<div class="form-group">
+    <label for="eventTitle">Title</label>
+    <input type="text" class="form-control" id="event-title" aria-describedby="eventTitle" value="${objEvent.title}">
+  </div>
+  <div class="form-group">
+    <label for="eventDate">Date</label>
+    <input type="date" class="form-control" id="event-date" value="${objEvent.date}">
+  </div>
+  <div class="form-group">
+    <label for="eventImage">Image Url</label>
+    <input type="url" class="form-control" id="event-image" value="${objEvent.image}">
+  </div>
+  <div class="form-group" id="select-food">
+  </div>
+  <div class="form-group" id="select-staff">
+  </div>
+  <div class="form-group" id="select-show">
+  </div>
+  <div class="form-group" id="select-souvenir">
+  </div>
+  <button type="submit" class="btn btn-primary" id="submit-event-form">Submit</button>
+</form>`;
+
+  selectFood(objData.food);
+  selectSouvenirs(objData.souvenirs);
+  selectShow(objData.shows);
+  selectStaff(objData.staff);
+};
+
+export default editEventForm;

--- a/src/javascripts/components/forms/editEventForm.js
+++ b/src/javascripts/components/forms/editEventForm.js
@@ -27,7 +27,7 @@ const editEventForm = (objEvent, objData) => {
   </div>
   <div class="form-group" id="select-souvenir">
   </div>
-  <button type="submit" class="btn btn-primary" id="submit-event-form">Submit</button>
+  <button type="submit" class="btn btn-primary" id="submit-edit-event-form--${objEvent.firebaseKey}">Submit</button>
 </form>`;
 
   selectFood(objData.food);

--- a/src/javascripts/components/forms/selectItems.js
+++ b/src/javascripts/components/forms/selectItems.js
@@ -39,7 +39,6 @@ const selectStaff = (selectedStaffArr) => {
       let checked = '';
       if (selectedStaffArr) {
         selectedStaffArr.forEach((staff) => {
-          console.warn(staff.staff_firebaseKey, item.firebaseKey);
           if (staff.staff_firebaseKey === item.firebaseKey) {
             checked = 'checked';
           }
@@ -66,7 +65,6 @@ const selectShow = (selectedShowsArr) => {
       let checked = '';
       if (selectedShowsArr) {
         selectedShowsArr.forEach((show) => {
-          console.warn(show.show_firebaseKey, item.firebaseKey);
           if (show.show_firebaseKey === item.firebaseKey) {
             checked = 'checked';
           }
@@ -93,7 +91,6 @@ const selectSouvenirs = (selectedSouvenirsArr) => {
       let checked = '';
       if (selectedSouvenirsArr) {
         selectedSouvenirsArr.forEach((souvenir) => {
-          console.warn(souvenir.souvenir_firebaseKey, item.firebaseKey);
           if (souvenir.souvenir_firebaseKey === item.firebaseKey) {
             checked = 'checked';
           }

--- a/src/javascripts/components/forms/selectItems.js
+++ b/src/javascripts/components/forms/selectItems.js
@@ -5,8 +5,12 @@ import { getAllFood } from '../../helpers/data/foodData';
 
 const selectFood = () => {
   let domString = `<label for="food">Food</label>
+    <div class="label-container">
+      <label class="name-label">Name</label>
+      <label class="quantity-label">Quantity</label>
+    </div>
   <div class="checkbox-container">
-  <ul class="check-box" id="ul-food">`;
+    <ul class="check-box" id="ul-food">`;
 
   getAllFood().then((foodArray) => {
     foodArray.forEach((item) => {
@@ -14,7 +18,8 @@ const selectFood = () => {
         <input type="checkbox" id="food_checkbox--${item.firebaseKey}"
           name="food_checkbox--${item.name}" value="${item.firebaseKey}">
           <label for="food_checkbox--${item.name}">${item.name}</label>
-          <input type="number" min="0" step="1"/></li>`;
+          <input type="number" class="module_count" min="0" step="1"
+          id="food_count--${item.firebaseKey}"/></li>`;
     });
 
     domString += '</ul></div>';
@@ -60,15 +65,21 @@ const selectShow = () => {
 
 const selectSouvenirs = () => {
   let domString = `<label for="souvenirs">Souvenirs</label>
-      <div class="checkbox-container">
-      <ul class="check-box" id="ul-souvenir">`;
+    <div class="label-container">
+      <label class="name-label">Name</label>
+      <label class="quantity-label">Quantity</label>
+    </div>
+  <div class="checkbox-container">
+    <ul class="check-box" id="ul-souvenir">`;
 
   getAllSouvenirs().then((souvenirArray) => {
     souvenirArray.forEach((item) => {
       domString += `<li>
         <input type="checkbox" id="souvenir_checkbox--${item.firebaseKey}"
           name="souvenir_checkbox--${item.name}" value="${item.firebaseKey}">
-          <label for="souvenir_checkbox--${item.name}">${item.name}</label></li>`;
+          <label for="souvenir_checkbox--${item.name}">${item.name}</label>
+          <input type="number" class="module_count" min="0" step="1"
+          id="souvenir_count--${item.firebaseKey}"/></li>`;
     });
     domString += '</ul></div>';
 

--- a/src/javascripts/components/forms/selectItems.js
+++ b/src/javascripts/components/forms/selectItems.js
@@ -15,10 +15,12 @@ const selectFood = (selectedFoodArr) => {
   getAllFood().then((foodArr) => {
     foodArr.forEach((item) => {
       let checked = '';
+      let count = '';
       if (selectedFoodArr) {
         selectedFoodArr.forEach((food) => {
           if (food.food_firebaseKey === item.firebaseKey) {
             checked = 'checked';
+            count = food.count;
           }
         });
       }
@@ -27,7 +29,7 @@ const selectFood = (selectedFoodArr) => {
           name="food_checkbox--${item.name}" value="${item.firebaseKey}" ${checked}>
           <label for="food_checkbox--${item.name}">${item.name}</label>
           <input type="number" class="module_count" min="0" step="1"
-          id="food_count--${item.firebaseKey}"/></li>`;
+          id="food_count--${item.firebaseKey}" value="${count}"></li>`;
     });
 
     domString += '</ul></div>';
@@ -99,10 +101,12 @@ const selectSouvenirs = (selectedSouvenirsArr) => {
   getAllSouvenirs().then((souvenirArray) => {
     souvenirArray.forEach((item) => {
       let checked = '';
+      let count = '';
       if (selectedSouvenirsArr) {
         selectedSouvenirsArr.forEach((souvenir) => {
           if (souvenir.souvenir_firebaseKey === item.firebaseKey) {
             checked = 'checked';
+            count = souvenir.count;
           }
         });
       }
@@ -111,7 +115,7 @@ const selectSouvenirs = (selectedSouvenirsArr) => {
           name="souvenir_checkbox--${item.name}" value="${item.firebaseKey}" ${checked}>
           <label for="souvenir_checkbox--${item.name}">${item.name}</label>
           <input type="number" class="module_count" min="0" step="1"
-          id="souvenir_count--${item.firebaseKey}"/></li>`;
+          id="souvenir_count--${item.firebaseKey}" value="${count}"></li>`;
     });
 
     domString += '</ul></div>';

--- a/src/javascripts/components/forms/selectItems.js
+++ b/src/javascripts/components/forms/selectItems.js
@@ -3,16 +3,24 @@ import { getAllShows } from '../../helpers/data/showsData';
 import { getAllStaff } from '../../helpers/data/staffData';
 import { getAllFood } from '../../helpers/data/foodData';
 
-const selectFood = () => {
+const selectFood = (selectedFoodArr) => {
   let domString = `<label for="food">Food</label>
   <div class="checkbox-container">
   <ul class="check-box" id="ul-food">`;
 
-  getAllFood().then((foodArray) => {
-    foodArray.forEach((item) => {
+  getAllFood().then((foodArr) => {
+    foodArr.forEach((item) => {
+      let checked = '';
+      if (selectedFoodArr) {
+        selectedFoodArr.forEach((food) => {
+          if (food.food_firebaseKey === item.firebaseKey) {
+            checked = 'checked';
+          }
+        });
+      }
       domString += `<li>
         <input type="checkbox" id="food_checkbox--${item.firebaseKey}"
-          name="food_checkbox--${item.name}" value="${item.firebaseKey}">
+          name="food_checkbox--${item.name}" value="${item.firebaseKey}" ${checked}>
           <label for="food_checkbox--${item.name}">${item.name}</label></li>`;
     });
 
@@ -21,16 +29,25 @@ const selectFood = () => {
   });
 };
 
-const selectStaff = () => {
+const selectStaff = (selectedStaffArr) => {
   let domString = `<label for="staff">Staff</label>
   <div class="checkbox-container">
   <ul class="check-box" id="ul-staff">`;
 
   getAllStaff().then((staffArray) => {
     staffArray.forEach((item) => {
+      let checked = '';
+      if (selectedStaffArr) {
+        selectedStaffArr.forEach((staff) => {
+          console.warn(staff.staff_firebaseKey, item.firebaseKey);
+          if (staff.staff_firebaseKey === item.firebaseKey) {
+            checked = 'checked';
+          }
+        });
+      }
       domString += `<li>
         <input type="checkbox" id="staff_checkbox--${item.firebaseKey}"
-          name="staff_checkbox--${item.first_name}" value="${item.firebaseKey}">
+          name="staff_checkbox--${item.first_name}" value="${item.firebaseKey}" ${checked}>
           <label for="staff_checkbox--${item.first_name}">${item.first_name} ${item.last_name}</label></li>`;
     });
 
@@ -39,16 +56,25 @@ const selectStaff = () => {
   });
 };
 
-const selectShow = () => {
+const selectShow = (selectedShowsArr) => {
   let domString = `<label for="shows">Shows</label>
     <div class="checkbox-container">
     <ul class="check-box" id="ul-show">`;
 
   getAllShows().then((showArray) => {
     showArray.forEach((item) => {
+      let checked = '';
+      if (selectedShowsArr) {
+        selectedShowsArr.forEach((show) => {
+          console.warn(show.show_firebaseKey, item.firebaseKey);
+          if (show.show_firebaseKey === item.firebaseKey) {
+            checked = 'checked';
+          }
+        });
+      }
       domString += `<li>
       <input type="checkbox" id="staff_checkbox--${item.firebaseKey}"
-        name="show_checkbox--${item.name}" value="${item.firebaseKey}">
+        name="show_checkbox--${item.name}" value="${item.firebaseKey}" ${checked}>
         <label for="show_checkbox--${item.name}">${item.name}</label></li>`;
     });
 
@@ -57,16 +83,25 @@ const selectShow = () => {
   });
 };
 
-const selectSouvenirs = () => {
+const selectSouvenirs = (selectedSouvenirsArr) => {
   let domString = `<label for="souvenirs">Souvenirs</label>
       <div class="checkbox-container">
       <ul class="check-box" id="ul-souvenir">`;
 
   getAllSouvenirs().then((souvenirArray) => {
     souvenirArray.forEach((item) => {
+      let checked = '';
+      if (selectedSouvenirsArr) {
+        selectedSouvenirsArr.forEach((souvenir) => {
+          console.warn(souvenir.souvenir_firebaseKey, item.firebaseKey);
+          if (souvenir.souvenir_firebaseKey === item.firebaseKey) {
+            checked = 'checked';
+          }
+        });
+      }
       domString += `<li>
         <input type="checkbox" id="souvenir_checkbox--${item.firebaseKey}"
-          name="souvenir_checkbox--${item.name}" value="${item.firebaseKey}">
+          name="souvenir_checkbox--${item.name}" value="${item.firebaseKey}" ${checked}>
           <label for="souvenir_checkbox--${item.name}">${item.name}</label></li>`;
     });
     domString += '</ul></div>';

--- a/src/javascripts/components/forms/selectItems.js
+++ b/src/javascripts/components/forms/selectItems.js
@@ -13,7 +13,8 @@ const selectFood = () => {
       domString += `<li>
         <input type="checkbox" id="food_checkbox--${item.firebaseKey}"
           name="food_checkbox--${item.name}" value="${item.firebaseKey}">
-          <label for="food_checkbox--${item.name}">${item.name}</label></li>`;
+          <label for="food_checkbox--${item.name}">${item.name}</label>
+          <input type="number" min="0" step="1"/></li>`;
     });
 
     domString += '</ul></div>';

--- a/src/javascripts/components/showEvents.js
+++ b/src/javascripts/components/showEvents.js
@@ -13,6 +13,7 @@ const showEvents = (array) => {
         <a href="#" id="show-event-title"><h5 id="event-title--${item.firebaseKey}" class="card-title mt-1 text-center">${item.title}</h5></a>
           <p class="card-text" id="show-event-date">${item.date}</p>
           <button type="button" id="event-details-btn--${item.firebaseKey}" class="btn btn-sm event-details-btn">View details</button>
+          <button type="button" class="btn edit-btn" id="event-edit-btn--${item.firebaseKey}"><i id="event-edit-icon--${item.firebaseKey}" class="fas fa-edit fa-lg"></i></button>
           <button class="btn delete-btn" data-toggle="modal" data-target="#formModal" id="delete-modal-event--${item.firebaseKey}"><i class="fas fa-trash-alt" id="delete-modal-event--${item.firebaseKey}"></i></button>
       </div>
     </div>`;

--- a/src/javascripts/components/showSingleEvent.js
+++ b/src/javascripts/components/showSingleEvent.js
@@ -71,8 +71,6 @@ const souvenirQuad = (souvenirArr) => {
   });
 };
 
-// const eventName = ()
-
 const showSingleEvent = (Obj, eventId) => {
   getSingleEvent(eventId).then((eventObj) => {
     document.querySelector('#content-container').innerHTML = '';

--- a/src/javascripts/components/showSingleEvent.js
+++ b/src/javascripts/components/showSingleEvent.js
@@ -8,49 +8,67 @@ import { getSingleEvent } from '../helpers/data/eventsData';
 const foodQuad = (foodArr) => {
   const foodQuadrant = document.querySelector('#food-quad');
   foodQuadrant.innerHTML = '';
-  foodQuadrant.innerHTML = '<ul class="item-list">';
+  foodQuadrant.innerHTML = '<div class="container item-list" id="food-list"></div>';
+  document.querySelector('#food-list').innerHTML = `
+    <div class="row row-header">
+      <div class="col-9 list-name">Name</div>
+      <div class="col-3 list-count">Count</div>
+    </div>`;
   foodArr.forEach((foodItem) => {
     getSingleFood(foodItem.food_firebaseKey).then((foodObj) => {
-      foodQuadrant.innerHTML += `<li>${foodObj.name}</li>`;
+      document.querySelector('#food-list').innerHTML += `
+      <div class="row">
+        <div class="col-9 list-name">${foodObj.name}</div>
+        <div class="col-3 list-count">${foodItem.count}</div>
+      </div>`;
     });
   });
-  foodQuadrant.innerHTML += '</ul>';
 };
 
 const showQuad = (showArr) => {
   const showQuadrant = document.querySelector('#show-quad');
   showQuadrant.innerHTML = '';
-  showQuadrant.innerHTML = '<ul class="item-list">';
+  showQuadrant.innerHTML = '<div class="container item-list" id="show-list"></div>';
   showArr.forEach((showItem) => {
     getSingleShow(showItem.show_firebaseKey).then((showObj) => {
-      showQuadrant.innerHTML += `<li>${showObj.name}</li>`;
+      document.querySelector('#show-list').innerHTML += `
+        <div class="col list-name">${showObj.name}</div>`;
     });
   });
-  showQuadrant.innerHTML += '</ul>';
 };
 
 const staffQuad = (staffArr) => {
   const staffQuadrant = document.querySelector('#staff-quad');
   staffQuadrant.innerHTML = '';
-  staffQuadrant.innerHTML = '<ul class="item-list">';
+  staffQuadrant.innerHTML = '<div class="container item-list" id="staff-list"></div>';
   staffArr.forEach((showItem) => {
     getSingleStaff(showItem.staff_firebaseKey).then((staffObj) => {
-      staffQuadrant.innerHTML += `<li>${staffObj.first_name} ${staffObj.last_name}</li>`;
+      document.querySelector('#staff-list').innerHTML += `
+        <div class="row">
+          <div class="col list-name">${staffObj.first_name} ${staffObj.last_name}</div>
+        </div>`;
     });
   });
-  staffQuadrant.innerHTML += '</ul>';
 };
 
 const souvenirQuad = (souvenirArr) => {
   const souvenirQuadrant = document.querySelector('#souvenir-quad');
   souvenirQuadrant.innerHTML = '';
-  souvenirQuadrant.innerHTML = '<ul class="item-list">';
+  souvenirQuadrant.innerHTML = '<div class="container item-list" id="souvenir-list"></div>';
+  document.querySelector('#souvenir-list').innerHTML = `
+    <div class="row row-header">
+      <div class="col-9 list-name">Name</div>
+      <div class="col-3 list-count">Count</div>
+    </div>`;
   souvenirArr.forEach((showItem) => {
     getSingleSouvenir(showItem.souvenir_firebaseKey).then((souvenirObj) => {
-      souvenirQuadrant.innerHTML += `<li>${souvenirObj.name}</li>`;
+      document.querySelector('#souvenir-list').innerHTML += `
+      <div class="row">
+        <div class="col-9 list-name">${souvenirObj.name}</div>
+        <div class="col-3 list-count">${showItem.count}</div>
+      </div>`;
     });
   });
-  souvenirQuadrant.innerHTML += '</ul>';
 };
 
 // const eventName = ()
@@ -59,7 +77,28 @@ const showSingleEvent = (Obj, eventId) => {
   getSingleEvent(eventId).then((eventObj) => {
     document.querySelector('#content-container').innerHTML = '';
     document.querySelector('#add-button-container').innerHTML = '';
-    document.querySelector('#content-container').innerHTML += `<div class="event-a"><h1>Event Name:</h1><div class="l" id="event-name"></div>${eventObj.title}</div><div class="event-b"><h1>Event Date:</h1><div class="l" id="event-date"></div>${eventObj.date}</div><div class="event-quad"><h1>Food</h1><div class="l" id="food-quad"></div></div><div class="event-quad"><h1>Staff</h1><div class="l" id="staff-quad"></div></div><div class="event-quad"><h1>Shows</h1><div class="l" id="show-quad"></div></div><div class="event-quad"><h1>Souvenirs</h1><div class="l" id="souvenir-quad"></div></div>`;
+    document.querySelector('#content-container').innerHTML += `
+      <div class="event-a">
+        <div class="l" id="event-name"><h1>${eventObj.title}<h1></div>
+      </div>
+        <div class="event-b"><div class="l" id="event-date"><h2>${eventObj.date}</h2></div>
+      </div>
+      <div class="event-quad">
+        <h2>Shows</h2>
+        <div class="l" id="show-quad"></div>
+      </div>
+      <div class="event-quad">
+        <h2>Staff</h2>
+        <div class="l" id="staff-quad"></div>
+      </div>
+      <div class="event-quad">
+        <h2>Food</h2>
+        <div class="l" id="food-quad"></div>
+      </div>
+      </div><div class="event-quad">
+        <h2>Souvenirs</h2>
+        <div class="l" id="souvenir-quad"></div>
+      </div>`;
     foodQuad(Obj.food);
     showQuad(Obj.shows);
     staffQuad(Obj.staff);

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -38,13 +38,16 @@ import { showStaffReadOnly } from '../components/readOnlyPrinters/showStaffReadO
 import printShowsReadOnly from '../components/readOnlyPrinters/showShowsReadOnly';
 import { showSouvenirsReadOnly } from '../components/readOnlyPrinters/showSouvenirsReadOnly';
 import {
-  getSingleEvent, deleteEvent, getAllEvents
+  getSingleEvent, getAllEvents
 } from '../helpers/data/eventsData';
 import deleteConfirm from '../components/forms/deleteConfirm';
 import addEventForm from '../components/forms/addEventForm';
 import { showEvents } from '../components/showEvents';
 import showSingleEvent from '../components/showSingleEvent';
-import { eventsEvents, editEvent, submitUpdateEvent } from './eventsEvents';
+import {
+  eventsEvents, editEvent,
+  submitUpdateEvent, deleteEventWithData
+} from './eventsEvents';
 import { getAllEventItems } from '../helpers/data/eventsRelationships';
 
 const eventListeners = (e) => {
@@ -287,7 +290,7 @@ const eventListeners = (e) => {
 
   if (e.target.id.includes('delete-event')) {
     const firebaseKey = e.target.id.split('--')[1];
-    deleteEvent(firebaseKey).then((eventsArray) => showEvents(eventsArray));
+    deleteEventWithData(firebaseKey).then((eventsArray) => showEvents(eventsArray));
     $('#formModal').modal('toggle');
   }
 

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -299,6 +299,11 @@ const eventListeners = (e) => {
     const firebaseKey = e.target.id.split('--')[1];
     editEvent(firebaseKey);
   }
+  if (e.target.id.includes('submit-edit-event-form')) {
+    e.preventDefault();
+    // const firebaseKey = e.target.id.split('--')[1];
+    console.warn('EDIT EVENT');
+  }
 };
 
 const domEvents = () => {

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -44,7 +44,7 @@ import deleteConfirm from '../components/forms/deleteConfirm';
 import addEventForm from '../components/forms/addEventForm';
 import { showEvents } from '../components/showEvents';
 import showSingleEvent from '../components/showSingleEvent';
-import { eventsEvents, editEvent } from './eventsEvents';
+import { eventsEvents, editEvent, submitUpdateEvent } from './eventsEvents';
 import { getAllEventItems } from '../helpers/data/eventsRelationships';
 
 const eventListeners = (e) => {
@@ -281,7 +281,8 @@ const eventListeners = (e) => {
   }
 
   if (e.target.id.includes('submit-event-form')) {
-    eventsEvents(e);
+    e.preventDefault();
+    eventsEvents();
   }
 
   if (e.target.id.includes('delete-event')) {
@@ -301,8 +302,8 @@ const eventListeners = (e) => {
   }
   if (e.target.id.includes('submit-edit-event-form')) {
     e.preventDefault();
-    // const firebaseKey = e.target.id.split('--')[1];
-    console.warn('EDIT EVENT');
+    const firebaseKey = e.target.id.split('--')[1];
+    submitUpdateEvent(firebaseKey);
   }
 };
 

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -44,7 +44,7 @@ import deleteConfirm from '../components/forms/deleteConfirm';
 import addEventForm from '../components/forms/addEventForm';
 import { showEvents } from '../components/showEvents';
 import showSingleEvent from '../components/showSingleEvent';
-import eventsEvents from './eventsEvents';
+import { eventsEvents, editEvent } from './eventsEvents';
 import { getAllEventItems } from '../helpers/data/eventsRelationships';
 
 const eventListeners = (e) => {
@@ -277,7 +277,6 @@ const eventListeners = (e) => {
   }
   // Form input value stuff
   if (e.target.id.includes('add-new-event-btn')) {
-    console.warn('add event button');
     addEventForm();
   }
 
@@ -294,6 +293,11 @@ const eventListeners = (e) => {
   if (e.target.id.includes('event-details-btn')) {
     const firebaseKey = e.target.id.split('--')[1];
     getAllEventItems(firebaseKey).then((obj) => showSingleEvent(obj));
+  }
+  if (e.target.id.includes('event-edit-btn')
+      || e.target.id.includes('event-edit-icon')) {
+    const firebaseKey = e.target.id.split('--')[1];
+    editEvent(firebaseKey);
   }
 };
 

--- a/src/javascripts/events/eventsEvents.js
+++ b/src/javascripts/events/eventsEvents.js
@@ -19,9 +19,7 @@ const eventsEvents = (e) => {
     const souvenirObject = {};
     const eventSouvenirArray = document.querySelector('#ul-souvenir').childNodes;
     eventSouvenirArray.forEach((element) => {
-      console.warn(element.childNodes[1].checked);
       if (element.childNodes[1].checked) {
-        // console.warn(element.childNodes[1].value);
         souvenirObject.event_firebaseKey = eventKey;
         souvenirObject.souvenir_firebaseKey = element.childNodes[1].value;
         createEventSouvenirsRelationship(souvenirObject).then(() => console.warn(souvenirObject));

--- a/src/javascripts/events/eventsEvents.js
+++ b/src/javascripts/events/eventsEvents.js
@@ -2,7 +2,7 @@ import firebase from 'firebase/app';
 import 'firebase/auth';
 import {
   createEvent, updateEvent,
-  getAllEvents, getSingleEvent
+  getAllEvents, getSingleEvent, deleteEvent
 } from '../helpers/data/eventsData';
 import { createEventSouvenirsRelationship, deleteEventSouvenirs } from '../helpers/data/eventsSouvenirs';
 import { createEventShowRelationship, deleteEventShows } from '../helpers/data/eventsShows';
@@ -127,7 +127,13 @@ const submitUpdateEvent = (eventId) => {
   updateExistingEvent(eventId);
 };
 
+const deleteEventWithData = (eventId) => {
+  console.warn('clearing event data');
+  clearEventData(eventId);
+  return deleteEvent(eventId);
+};
+
 export {
   eventsEvents, editEvent,
-  submitUpdateEvent
+  submitUpdateEvent, deleteEventWithData
 };

--- a/src/javascripts/events/eventsEvents.js
+++ b/src/javascripts/events/eventsEvents.js
@@ -1,16 +1,18 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
-import { createEvent, getAllEvents, getSingleEvent } from '../helpers/data/eventsData';
-import { createEventSouvenirsRelationship } from '../helpers/data/eventsSouvenirs';
-import { createEventShowsRelationship } from '../helpers/data/eventsShows';
-import { createEventStaffRelationship } from '../helpers/data/eventsStaff';
-import { createEventFoodRelationship } from '../helpers/data/eventsFood';
+import {
+  createEvent, updateEvent,
+  getAllEvents, getSingleEvent
+} from '../helpers/data/eventsData';
+import { createEventSouvenirsRelationship, deleteEventSouvenirs } from '../helpers/data/eventsSouvenirs';
+import { createEventShowRelationship, deleteEventShows } from '../helpers/data/eventsShows';
+import { createEventStaffRelationship, deleteEventStaff } from '../helpers/data/eventsStaff';
+import { createEventFoodRelationship, deleteEventFood } from '../helpers/data/eventsFood';
 import { showEvents } from '../components/showEvents';
 import editEventForm from '../components/forms/editEventForm';
 import { getAllEventItems } from '../helpers/data/eventsRelationships';
 
-const eventsEvents = (e) => {
-  e.preventDefault();
+const eventsEvents = () => {
   const eventObject = {
     date: document.querySelector('#event-date').value,
     title: document.querySelector('#event-title').value,
@@ -34,7 +36,7 @@ const eventsEvents = (e) => {
       if (element.childNodes[1].checked) {
         showObject.event_firebaseKey = eventKey;
         showObject.show_firebaseKey = element.childNodes[1].value;
-        createEventShowsRelationship(showObject);
+        createEventShowRelationship(showObject);
       }
     });
     const staffObject = {};
@@ -59,10 +61,73 @@ const eventsEvents = (e) => {
   });
 };
 
+const updateExistingEvent = (eventId) => {
+  const eventObject = {
+    date: document.querySelector('#event-date').value,
+    title: document.querySelector('#event-title').value,
+    image: document.querySelector('#event-image').value,
+    uid: firebase.auth().currentUser.uid
+  };
+  updateEvent(eventId, eventObject).then(() => {
+    const souvenirObject = {};
+    const eventSouvenirArray = document.querySelector('#ul-souvenir').childNodes;
+    eventSouvenirArray.forEach((element) => {
+      if (element.childNodes[1].checked) {
+        souvenirObject.event_firebaseKey = eventId;
+        souvenirObject.souvenir_firebaseKey = element.childNodes[1].value;
+        createEventSouvenirsRelationship(souvenirObject);
+      }
+    });
+    const showObject = {};
+    const eventShowArray = document.querySelector('#ul-show').childNodes;
+    eventShowArray.forEach((element) => {
+      if (element.childNodes[1].checked) {
+        showObject.event_firebaseKey = eventId;
+        showObject.show_firebaseKey = element.childNodes[1].value;
+        createEventShowRelationship(showObject);
+      }
+    });
+    const staffObject = {};
+    const eventStaffArray = document.querySelector('#ul-staff').childNodes;
+    eventStaffArray.forEach((element) => {
+      if (element.childNodes[1].checked) {
+        staffObject.event_firebaseKey = eventId;
+        staffObject.staff_firebaseKey = element.childNodes[1].value;
+        createEventStaffRelationship(staffObject);
+      }
+    });
+    const foodObject = {};
+    const eventFoodArray = document.querySelector('#ul-food').childNodes;
+    eventFoodArray.forEach((element) => {
+      if (element.childNodes[1].checked) {
+        foodObject.event_firebaseKey = eventId;
+        foodObject.food_firebaseKey = element.childNodes[1].value;
+        createEventFoodRelationship(foodObject);
+      }
+    });
+    getAllEvents().then((eventsArray) => showEvents(eventsArray));
+  });
+};
+
 const editEvent = (firebaseKey) => {
   getSingleEvent(firebaseKey).then((event) => {
     getAllEventItems(event.firebaseKey).then((obj) => editEventForm(event, obj));
   });
 };
 
-export { eventsEvents, editEvent };
+const clearEventData = (eventId) => {
+  deleteEventFood(eventId);
+  deleteEventStaff(eventId);
+  deleteEventShows(eventId);
+  deleteEventSouvenirs(eventId);
+};
+
+const submitUpdateEvent = (eventId) => {
+  clearEventData(eventId);
+  updateExistingEvent(eventId);
+};
+
+export {
+  eventsEvents, editEvent,
+  submitUpdateEvent
+};

--- a/src/javascripts/events/eventsEvents.js
+++ b/src/javascripts/events/eventsEvents.js
@@ -1,11 +1,13 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
-import { createEvent, getAllEvents } from '../helpers/data/eventsData';
+import { createEvent, getAllEvents, getSingleEvent } from '../helpers/data/eventsData';
 import { createEventSouvenirsRelationship } from '../helpers/data/eventsSouvenirs';
 import { createEventShowsRelationship } from '../helpers/data/eventsShows';
 import { createEventStaffRelationship } from '../helpers/data/eventsStaff';
 import { createEventFoodRelationship } from '../helpers/data/eventsFood';
 import { showEvents } from '../components/showEvents';
+import editEventForm from '../components/forms/editEventForm';
+import { getAllEventItems } from '../helpers/data/eventsRelationships';
 
 const eventsEvents = (e) => {
   e.preventDefault();
@@ -59,4 +61,10 @@ const eventsEvents = (e) => {
   });
 };
 
-export default eventsEvents;
+const editEvent = (firebaseKey) => {
+  getSingleEvent(firebaseKey).then((event) => {
+    getAllEventItems(event.firebaseKey).then((obj) => editEventForm(event, obj));
+  });
+};
+
+export { eventsEvents, editEvent };

--- a/src/javascripts/events/eventsEvents.js
+++ b/src/javascripts/events/eventsEvents.js
@@ -24,9 +24,14 @@ const eventsEvents = () => {
     const souvenirObject = {};
     const eventSouvenirArray = document.querySelector('#ul-souvenir').childNodes;
     eventSouvenirArray.forEach((element) => {
+      let count = element.childNodes[5].value;
+      if (!count) {
+        count = '0';
+      }
       if (element.childNodes[1].checked) {
         souvenirObject.event_firebaseKey = eventKey;
         souvenirObject.souvenir_firebaseKey = element.childNodes[1].value;
+        souvenirObject.count = parseInt(count, 10);
         createEventSouvenirsRelationship(souvenirObject);
       }
     });
@@ -51,9 +56,14 @@ const eventsEvents = () => {
     const foodObject = {};
     const eventFoodArray = document.querySelector('#ul-food').childNodes;
     eventFoodArray.forEach((element) => {
+      let count = element.childNodes[5].value;
+      if (!count) {
+        count = '0';
+      }
       if (element.childNodes[1].checked) {
         foodObject.event_firebaseKey = eventKey;
         foodObject.food_firebaseKey = element.childNodes[1].value;
+        foodObject.count = parseInt(count, 10);
         createEventFoodRelationship(foodObject);
       }
     });

--- a/src/javascripts/events/eventsEvents.js
+++ b/src/javascripts/events/eventsEvents.js
@@ -72,9 +72,14 @@ const updateExistingEvent = (eventId) => {
     const souvenirObject = {};
     const eventSouvenirArray = document.querySelector('#ul-souvenir').childNodes;
     eventSouvenirArray.forEach((element) => {
+      let count = element.childNodes[5].value;
+      if (!count) {
+        count = '0';
+      }
       if (element.childNodes[1].checked) {
         souvenirObject.event_firebaseKey = eventId;
         souvenirObject.souvenir_firebaseKey = element.childNodes[1].value;
+        souvenirObject.count = parseInt(count, 10);
         createEventSouvenirsRelationship(souvenirObject);
       }
     });
@@ -99,9 +104,14 @@ const updateExistingEvent = (eventId) => {
     const foodObject = {};
     const eventFoodArray = document.querySelector('#ul-food').childNodes;
     eventFoodArray.forEach((element) => {
+      let count = element.childNodes[5].value;
+      if (!count) {
+        count = '0';
+      }
       if (element.childNodes[1].checked) {
         foodObject.event_firebaseKey = eventId;
         foodObject.food_firebaseKey = element.childNodes[1].value;
+        foodObject.count = parseInt(count, 10);
         createEventFoodRelationship(foodObject);
       }
     });
@@ -128,7 +138,6 @@ const submitUpdateEvent = (eventId) => {
 };
 
 const deleteEventWithData = (eventId) => {
-  console.warn('clearing event data');
   clearEventData(eventId);
   return deleteEvent(eventId);
 };

--- a/src/javascripts/helpers/auth.js
+++ b/src/javascripts/helpers/auth.js
@@ -6,13 +6,7 @@ import startApp from './startApp';
 const checkLoginStatus = () => {
   firebase.initializeApp(firebaseConfig);
   firebase.auth().onAuthStateChanged((user) => {
-    if (user) {
-      // person is logged in do something...
-      startApp(user);
-    } else {
-      // person is NOT logged in
-      startApp(user);
-    }
+    startApp(user);
   });
 };
 

--- a/src/javascripts/helpers/data/eventsData.js
+++ b/src/javascripts/helpers/data/eventsData.js
@@ -33,8 +33,8 @@ const deleteEvent = (firebaseKey) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-const createEvent = (eventObject) => new Promise((resolve, reject) => {
-  axios.post(`${dbUrl}/events.json`, eventObject)
+const createEvent = (eventObj) => new Promise((resolve, reject) => {
+  axios.post(`${dbUrl}/events.json`, eventObj)
     .then((response) => {
       const body = { firebaseKey: response.data.name };
       axios.patch(`${dbUrl}/events/${response.data.name}.json`, body)
@@ -43,7 +43,19 @@ const createEvent = (eventObject) => new Promise((resolve, reject) => {
     });
 });
 
+const updateEvent = (eventId, eventObj) => new Promise((resolve, reject) => {
+  axios.patch(`${dbUrl}/events/${eventId}.json`, eventObj)
+    .then((response) => {
+      if (response.data.name) {
+        getSingleEvent(response.data.name)
+          .then((updatedObj) => resolve(updatedObj));
+      } else {
+        resolve([]);
+      }
+    }).catch((error) => reject(error));
+});
+
 export {
   getAllEvents, getEvents, getSingleEvent,
-  deleteEvent, createEvent
+  deleteEvent, createEvent, updateEvent
 };

--- a/src/javascripts/helpers/data/eventsFood.js
+++ b/src/javascripts/helpers/data/eventsFood.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import firebaseConfig from '../apiKeys';
 
+import { getEventFood } from './eventsRelationships';
+
 const dbUrl = firebaseConfig.databaseURL;
 
 const getEventsFoodTables = () => new Promise((resolve, reject) => {
@@ -23,4 +25,18 @@ const createEventFoodRelationship = (obj) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-export { getEventsFoodTables, createEventFoodRelationship };
+const deleteEventFoodRelationship = (tableId) => new Promise((resolve, reject) => {
+  axios.delete(`${dbUrl}/events_food/${tableId}.json`)
+    .then((response) => resolve(response))
+    .catch((error) => reject(error));
+});
+
+const deleteEventFood = (eventId) => {
+  getEventFood(eventId).then((foodArr) => {
+    foodArr.forEach((item) => deleteEventFoodRelationship(item.firebaseKey));
+  });
+};
+export {
+  getEventsFoodTables, createEventFoodRelationship,
+  deleteEventFood
+};

--- a/src/javascripts/helpers/data/eventsShows.js
+++ b/src/javascripts/helpers/data/eventsShows.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import firebaseConfig from '../apiKeys';
+import { getEventShows } from './eventsRelationships';
 
 const dbUrl = firebaseConfig.databaseURL;
 
@@ -14,7 +15,7 @@ const getEventsShowsTables = () => new Promise((resolve, reject) => {
     }).catch((error) => reject(error));
 });
 
-const createEventShowsRelationship = (obj) => new Promise((resolve, reject) => {
+const createEventShowRelationship = (obj) => new Promise((resolve, reject) => {
   axios.post(`${dbUrl}/events_shows.json`, obj)
     .then((response) => {
       const body = { firebaseKey: response.data.name };
@@ -23,4 +24,19 @@ const createEventShowsRelationship = (obj) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-export { getEventsShowsTables, createEventShowsRelationship };
+const deleteEventShowRelationship = (tableId) => new Promise((resolve, reject) => {
+  axios.delete(`${dbUrl}/events_shows/${tableId}.json`)
+    .then((response) => resolve(response))
+    .catch((error) => reject(error));
+});
+
+const deleteEventShows = (eventId) => {
+  getEventShows(eventId).then((showsArr) => {
+    showsArr.forEach((show) => deleteEventShowRelationship(show.firebaseKey));
+  });
+};
+
+export {
+  getEventsShowsTables, createEventShowRelationship,
+  deleteEventShows
+};

--- a/src/javascripts/helpers/data/eventsSouvenirs.js
+++ b/src/javascripts/helpers/data/eventsSouvenirs.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import firebaseConfig from '../apiKeys';
 
+import { getEventSouvenirs } from './eventsRelationships';
+
 const dbUrl = firebaseConfig.databaseURL;
 
 const getEventsSouvenirTables = () => new Promise((resolve, reject) => {
@@ -23,4 +25,19 @@ const createEventSouvenirsRelationship = (obj) => new Promise((resolve, reject) 
     .catch((error) => reject(error));
 });
 
-export { getEventsSouvenirTables, createEventSouvenirsRelationship };
+const deleteEventSouvenirRelationship = (tableId) => new Promise((resolve, reject) => {
+  axios.delete(`${dbUrl}/events_souvenirs/${tableId}.json`)
+    .then((response) => resolve(response))
+    .catch((error) => reject(error));
+});
+
+const deleteEventSouvenirs = (eventId) => {
+  getEventSouvenirs(eventId).then((souvenirsArr) => {
+    souvenirsArr.forEach((souvenir) => deleteEventSouvenirRelationship(souvenir.firebaseKey));
+  });
+};
+
+export {
+  getEventsSouvenirTables, createEventSouvenirsRelationship,
+  deleteEventSouvenirs
+};

--- a/src/javascripts/helpers/data/eventsStaff.js
+++ b/src/javascripts/helpers/data/eventsStaff.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import firebaseConfig from '../apiKeys';
 
+import { getEventStaff } from './eventsRelationships';
+
 const dbUrl = firebaseConfig.databaseURL;
 
 const getEventsStaffTables = () => new Promise((resolve, reject) => {
@@ -23,4 +25,19 @@ const createEventStaffRelationship = (obj) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-export { getEventsStaffTables, createEventStaffRelationship };
+const deleteEventStaffRelationship = (tableId) => new Promise((resolve, reject) => {
+  axios.delete(`${dbUrl}/events_staff/${tableId}.json`)
+    .then((response) => resolve(response))
+    .catch((error) => reject(error));
+});
+
+const deleteEventStaff = (eventId) => {
+  getEventStaff(eventId).then((staffArr) => {
+    staffArr.forEach((member) => deleteEventStaffRelationship(member.firebaseKey));
+  });
+};
+
+export {
+  getEventsStaffTables, createEventStaffRelationship,
+  deleteEventStaff
+};

--- a/src/javascripts/helpers/data/souvenirData.js
+++ b/src/javascripts/helpers/data/souvenirData.js
@@ -37,6 +37,7 @@ const getSingleSouvenir = (firebaseKey) => new Promise((resolve, reject) => {
     .then((response) => resolve(response.data))
     .catch((error) => reject(error));
 });
+
 // UPDATE A SOUVENIR'S INFO IN REAL TIME
 const updateSouvenir = (firebaseKey, souvenirObject) => new Promise((resolve, reject) => {
   axios.patch(`${dbUrl}/souvenirs/${firebaseKey}.json`, souvenirObject)

--- a/src/styles/checkboxList.scss
+++ b/src/styles/checkboxList.scss
@@ -13,4 +13,28 @@ div.checkbox-container {
 .checkbox-container li {
   line-height: 1em;
   text-align: left;
+  position: relative;
+}
+
+.module_count {
+  width: 3.5em;
+  position: absolute;
+  right: 10px;
+  height: 90%;
+}
+
+.label-container {
+  position: relative;
+}
+
+.name-label {
+  position: absolute;
+  left: 10px;
+  top: -30px;
+}
+
+.quantity-label {
+  position: absolute;
+  right: 10px;
+  top: -30px;
 }

--- a/src/styles/events.scss
+++ b/src/styles/events.scss
@@ -11,7 +11,7 @@
 }
 
 .event-quad {
-  padding: 50px 100px 50px 100px;
+  padding: 50px 50px;
   // display: inline;
   // flex-wrap: nowrap;
   flex: 50%;
@@ -20,5 +20,25 @@
 }
 
 .l {
-  font-size: 24px;
+  font-size: 1.2em;
+}
+
+.row-header {
+  border-bottom: 1px solid black;
+}
+
+.item-list {
+  list-style-type: none;
+}
+
+.list-name {
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  max-height: 1.5em;
+  max-width: 300px;
+}
+
+.list-count {
+  text-align: right;;
 }

--- a/src/styles/events.scss
+++ b/src/styles/events.scss
@@ -12,8 +12,6 @@
 
 .event-quad {
   padding: 50px 50px;
-  // display: inline;
-  // flex-wrap: nowrap;
   flex: 50%;
 }
 


### PR DESCRIPTION
## Description
Events can be updated and deleted along with the data associations of shows, staff, food and souvenirs tied to an event.  The user can also add the counts for food and souvenir Items when creating or updating events.  

The input form allows for easy selection using checkboxes, and integer input for items requiring a count.

Events are displayed on the single event details view page along with the selected shows, staff, souvenirs and food.

## Related Issue
#118
#119
#120
#121
#139

## Motivation and Context
This allow for full creation, read, update and delete of events with associated data.

## How Can This Be Tested?
Fetch jm-crud-with-counts. 
Update an event by clicking the edit button.  Select your changes and submit. View your changes in the single event view. 
Delete an event, By viewing the firebase realtime database, it is possible to view the associated join tables being deleted when deleting an event.
Additionally, create a new event and check that your selections appear in the single event view.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
